### PR TITLE
Update copyright notice for multiple authorship

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 # bartz/workflows/tests.yml
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Giacomo Petrillo
+Copyright (c) 2024-2025 The Bartz Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,6 +1,6 @@
 # bartz/benchmarks/__init__.py
 #
-# Copyright (c) 2025, Giacomo Petrillo
+# Copyright (c) 2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/benchmarks/rmse.py
+++ b/benchmarks/rmse.py
@@ -1,6 +1,6 @@
 # bartz/benchmarks/rmse.py
 #
-# Copyright (c) 2025, Giacomo Petrillo
+# Copyright (c) 2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/benchmarks/speed.py
+++ b/benchmarks/speed.py
@@ -1,6 +1,6 @@
 # bartz/benchmarks/speed.py
 #
-# Copyright (c) 2025, Giacomo Petrillo
+# Copyright (c) 2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/config/ipython/profile_default/ipython_config.py
+++ b/config/ipython/profile_default/ipython_config.py
@@ -1,6 +1,6 @@
 # bartz/config/ipython/profile_default/ipython_config.py
 #
-# Copyright (c) 2025, Giacomo Petrillo
+# Copyright (c) 2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,6 +1,6 @@
 /* bartz/docs/_static/custom.css
  *
- * Copyright (c) 2024-2025, Giacomo Petrillo
+ * Copyright (c) 2024-2025, The Bartz Contributors
  *
  * This file is part of bartz.
  *

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 <!--
 bartz/docs/changelog.md
 
-Copyright (c) 2024-2025, Giacomo Petrillo
+Copyright (c) 2024-2025, The Bartz Contributors
 
 This file is part of bartz.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # bartz/docs/conf.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #
@@ -89,7 +89,7 @@ import bartz
 # -- Project information -----------------------------------------------------
 
 project = f'bartz {version}'
-author = 'Giacomo Petrillo'
+author = 'The Bartz Contributors'
 
 now = datetime.datetime.now(tz=datetime.timezone.utc)
 year = '2024'

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/development.rst
 ..
-.. Copyright (c) 2024-2025, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/guide/index.rst
 ..
-.. Copyright (c) 2024, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..
@@ -10,10 +10,10 @@
 .. to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 .. copies of the Software, and to permit persons to whom the Software is
 .. furnished to do so, subject to the following conditions:
-.. 
+..
 .. The above copyright notice and this permission notice shall be included in all
 .. copies or substantial portions of the Software.
-.. 
+..
 .. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 .. IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 .. FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,6 +27,6 @@ Guide
 
 .. toctree::
     :maxdepth: 1
-    
+
     installation.rst
     quickstart.rst

--- a/docs/guide/installation.rst
+++ b/docs/guide/installation.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/installation.rst
 ..
-.. Copyright (c) 2024-2025, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..

--- a/docs/guide/quickstart.rst
+++ b/docs/guide/quickstart.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/quickstart.rst
 ..
-.. Copyright (c) 2024-2025, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/index.rst
 ..
-.. Copyright (c) 2024, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,7 +1,7 @@
 <!--
 bartz/docs/readme.md
 
-Copyright (c) 2024, Giacomo Petrillo
+Copyright (c) 2024-2025, The Bartz Contributors
 
 This file is part of bartz.
 

--- a/docs/reference/grove.rst
+++ b/docs/reference/grove.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/grove.rst
 ..
-.. Copyright (c) 2024, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..
@@ -10,10 +10,10 @@
 .. to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 .. copies of the Software, and to permit persons to whom the Software is
 .. furnished to do so, subject to the following conditions:
-.. 
+..
 .. The above copyright notice and this permission notice shall be included in all
 .. copies or substantial portions of the Software.
-.. 
+..
 .. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 .. IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 .. FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/reference/index.rst
 ..
-.. Copyright (c) 2024-2025, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..

--- a/docs/reference/interface.rst
+++ b/docs/reference/interface.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/interface.rst
 ..
-.. Copyright (c) 2024, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..
@@ -10,10 +10,10 @@
 .. to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 .. copies of the Software, and to permit persons to whom the Software is
 .. furnished to do so, subject to the following conditions:
-.. 
+..
 .. The above copyright notice and this permission notice shall be included in all
 .. copies or substantial portions of the Software.
-.. 
+..
 .. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 .. IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 .. FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/docs/reference/jaxext.rst
+++ b/docs/reference/jaxext.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/jaxext.rst
 ..
-.. Copyright (c) 2024-2025, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..

--- a/docs/reference/mcmcloop.rst
+++ b/docs/reference/mcmcloop.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/mcmcloop.rst
 ..
-.. Copyright (c) 2024-2025, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..

--- a/docs/reference/mcmcstep.rst
+++ b/docs/reference/mcmcstep.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/mcmcstep.rst
 ..
-.. Copyright (c) 2024, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..
@@ -10,10 +10,10 @@
 .. to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 .. copies of the Software, and to permit persons to whom the Software is
 .. furnished to do so, subject to the following conditions:
-.. 
+..
 .. The above copyright notice and this permission notice shall be included in all
 .. copies or substantial portions of the Software.
-.. 
+..
 .. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 .. IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 .. FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/docs/reference/prepcovars.rst
+++ b/docs/reference/prepcovars.rst
@@ -1,6 +1,6 @@
 .. bartz/docs/prepcovars.rst
 ..
-.. Copyright (c) 2024, Giacomo Petrillo
+.. Copyright (c) 2024-2025, The Bartz Contributors
 ..
 .. This file is part of bartz.
 ..
@@ -10,10 +10,10 @@
 .. to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 .. copies of the Software, and to permit persons to whom the Software is
 .. furnished to do so, subject to the following conditions:
-.. 
+..
 .. The above copyright notice and this permission notice shall be included in all
 .. copies or substantial portions of the Software.
-.. 
+..
 .. THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 .. IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 .. FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # bartz/pyproject.toml
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/src/bartz/BART.py
+++ b/src/bartz/BART.py
@@ -1,6 +1,6 @@
 # bartz/src/bartz/BART.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/src/bartz/__init__.py
+++ b/src/bartz/__init__.py
@@ -1,6 +1,6 @@
 # bartz/src/bartz/__init__.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/src/bartz/debug.py
+++ b/src/bartz/debug.py
@@ -1,6 +1,6 @@
 # bartz/src/bartz/debug.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/src/bartz/grove.py
+++ b/src/bartz/grove.py
@@ -1,6 +1,6 @@
 # bartz/src/bartz/grove.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/src/bartz/mcmcloop.py
+++ b/src/bartz/mcmcloop.py
@@ -1,6 +1,6 @@
 # bartz/src/bartz/mcmcloop.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/src/bartz/mcmcstep.py
+++ b/src/bartz/mcmcstep.py
@@ -1,6 +1,6 @@
 # bartz/src/bartz/mcmcstep.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/src/bartz/prepcovars.py
+++ b/src/bartz/prepcovars.py
@@ -1,6 +1,6 @@
 # bartz/src/bartz/prepcovars.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,6 @@
 # bartz/tests/__init__.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # bartz/tests/conftest.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/rbartpackages/BART.py
+++ b/tests/rbartpackages/BART.py
@@ -1,6 +1,6 @@
 # bartz/tests/rbartpackages/BART.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/rbartpackages/_base.py
+++ b/tests/rbartpackages/_base.py
@@ -1,6 +1,6 @@
 # bartz/tests/rbartpackages/_base.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/rbartpackages/bartMachine.py
+++ b/tests/rbartpackages/bartMachine.py
@@ -1,6 +1,6 @@
 # bartz/tests/rbartpackages/bartMachine.py
 #
-# Copyright (c) 2025, Giacomo Petrillo
+# Copyright (c) 2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/rbartpackages/dbarts.py
+++ b/tests/rbartpackages/dbarts.py
@@ -1,6 +1,6 @@
 # bartz/tests/rbartpackages/dbarts.py
 #
-# Copyright (c) 2025, Giacomo Petrillo
+# Copyright (c) 2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -1,6 +1,6 @@
 # bartz/tests/test_BART.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/test_jaxext.py
+++ b/tests/test_jaxext.py
@@ -1,6 +1,6 @@
 # bartz/tests/test_jaxext.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/test_mcmcloop.py
+++ b/tests/test_mcmcloop.py
@@ -1,6 +1,6 @@
 # bartz/tests/test_mcmcloop.py
 #
-# Copyright (c) 2025, Giacomo Petrillo
+# Copyright (c) 2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,6 +1,6 @@
 # bartz/tests/test_meta.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/test_mvbart.py
+++ b/tests/test_mvbart.py
@@ -1,3 +1,27 @@
+# bartz/tests/test_mvbart.py
+#
+# Copyright (c) 2025, The Bartz Contributors
+#
+# This file is part of bartz.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 """Test multivariate BART components."""
 
 import pytest

--- a/tests/test_prepcovars.py
+++ b/tests/test_prepcovars.py
@@ -1,6 +1,6 @@
 # bartz/tests/test_prepcovars.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,6 @@
 # bartz/tests/util.py
 #
-# Copyright (c) 2024-2025, Giacomo Petrillo
+# Copyright (c) 2024-2025, The Bartz Contributors
 #
 # This file is part of bartz.
 #


### PR DESCRIPTION
#10 was the first merged external contribution so I changed the copyright notices from my name to "The Bartz Contributors".

The authors list is generated automatically by github on the repo homepage, so I did not manually edit an AUTHORS file.