### PR TITLE
Fix failing benchmarks job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -249,5 +249,5 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           version: ${{ env.UV_VERSION }}
-      - run: uv run --group ci python -m asv machine --yes
+      - run: RPY2_CFFI_MODE=ABI uv run --group ci python -m asv machine --yes
       - run: make asv-quick


### PR DESCRIPTION
The tests-docs:benchmarks job flaky fails, typically I re-run it after the workflow ends and it works just fine. It's pretty inconvenient because it's required for merging, so I should fix it.