### PR TITLE
Single source of old Python version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 # Makefile for running tests, prepare and upload a release.
 
 COVERAGE_SUFFIX =
-OLD_PYTHON = 3.10
+OLD_PYTHON = $(shell uv run --group ci python -c 'import tomli; print(tomli.load(open("pyproject.toml", "rb"))["project"]["requires-python"].removeprefix(">="))')
 OLD_DATE = 2025-05-15
 
 .PHONY: all
@@ -125,7 +125,7 @@ update-deps:
 .PHONY: copy-version
 copy-version: src/bartz/_version.py
 src/bartz/_version.py: pyproject.toml
-	uv run --group only-local python -c 'import tomli, pathlib; version = tomli.load(open("pyproject.toml", "rb"))["project"]["version"]; pathlib.Path("src/bartz/_version.py").write_text(f"__version__ = {version!r}\n")'
+	uv run --group ci python -c 'import tomli, pathlib; version = tomli.load(open("pyproject.toml", "rb"))["project"]["version"]; pathlib.Path("src/bartz/_version.py").write_text(f"__version__ = {version!r}\n")'
 
 .PHONY: check-committed
 check-committed:
@@ -162,7 +162,7 @@ upload-test: check-committed
 	@read -s UV_PUBLISH_TOKEN && \
 	export UV_PUBLISH_TOKEN="$$UV_PUBLISH_TOKEN" && \
 	uv publish --check-url https://test.pypi.org/simple/ --publish-url https://test.pypi.org/legacy/
-	@VERSION=$$(uv run --group only-local python -c 'import tomli; print(tomli.load(open("pyproject.toml", "rb"))["project"]["version"])') && \
+	@VERSION=$$(uv run --group ci python -c 'import tomli; print(tomli.load(open("pyproject.toml", "rb"))["project"]["version"])') && \
 	echo "Try to install bartz $$VERSION from TestPyPI" && \
 	uv tool run --index https://test.pypi.org/simple/ --index-strategy unsafe-best-match --with "bartz==$$VERSION" python -c 'import bartz; print(bartz.__version__)'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ description = "Super-fast BART (Bayesian Additive Regression Trees) in Python"
 authors = [{ name = "Giacomo Petrillo", email = "info@giacomopetrillo.com" }]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.10" # also update OLD_PYTHON in makefile
+requires-python = ">=3.10"
 dependencies = [
     "equinox>=0.12.2",
     "jax>=0.5.3",
@@ -56,7 +56,6 @@ only-local = [
     "pre-commit>=4.2.0",
     "scikit-learn>=1.6.1",
     "snakeviz>=2.2.2",
-    "tomli>=2.2.1",
     "virtualenv>=20.31.2",
     "xgboost>=3.0.0",
 ]
@@ -74,6 +73,7 @@ ci = [
     "rpy2>=3.5.17",
     "sphinx>=8.1.3",
     "sphinx-autodoc-typehints>=3.0.1",
+    "tomli>=2.2.1",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -145,6 +145,7 @@ ci = [
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-autodoc-typehints", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx-autodoc-typehints", version = "3.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "tomli" },
 ]
 only-local = [
     { name = "appnope" },
@@ -155,7 +156,6 @@ only-local = [
     { name = "pre-commit" },
     { name = "scikit-learn" },
     { name = "snakeviz" },
-    { name = "tomli" },
     { name = "virtualenv" },
     { name = "xgboost" },
 ]
@@ -184,6 +184,7 @@ ci = [
     { name = "rpy2", specifier = ">=3.5.17" },
     { name = "sphinx", specifier = ">=8.1.3" },
     { name = "sphinx-autodoc-typehints", specifier = ">=3.0.1" },
+    { name = "tomli", specifier = ">=2.2.1" },
 ]
 only-local = [
     { name = "appnope", specifier = ">=0.1.4" },
@@ -193,7 +194,6 @@ only-local = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "scikit-learn", specifier = ">=1.6.1" },
     { name = "snakeviz", specifier = ">=2.2.2" },
-    { name = "tomli", specifier = ">=2.2.1" },
     { name = "virtualenv", specifier = ">=20.31.2" },
     { name = "xgboost", specifier = ">=3.0.0" },
 ]


### PR DESCRIPTION
Only pyproject.toml now contains the version of Python to test with
oldest supported dependencies.
