### PR TITLE
Bump oldest supported dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,11 @@ jobs:
               "args": "tests ARGS=--disable-problematic-sharding"
             },
             {
+              "id": "old",
+              "runs-on": "ubuntu-latest",
+              "args": "tests-old ARGS=--disable-problematic-sharding"
+            },
+            {
               "id": "single-cpu",
               "runs-on": "ubuntu-latest",
               "args": "tests ARGS=--num-cpu-devices=1 COVERAGE_SUFFIX=-single-cpu"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SKIP: no-commit-to-branch
+      RPY2_CFFI_MODE: ABI
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,16 +50,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      # this python is for the pre-commit action
       - uses: actions/setup-python@v6
         with:
           python-version-file: ".python-version"
+
+      # this python is for the pre-commit hooks
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
 
       - name: Determine base ref
         id: refs
         run: echo "from=${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (startsWith(github.ref, 'refs/heads/') && github.event.before) || '' }}" >> "$GITHUB_OUTPUT"
 
       - name: Run pre-commit on changed files
-        # even if I run it on all files below, it's convenient to see if something fails in new changes first
+        # even if we run it on all files below, it's convenient to see if something fails in new changes first
         if: steps.refs.outputs.from != ''
         uses: pre-commit/action@v3.0.1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,11 +92,6 @@ jobs:
               "args": "tests ARGS=--disable-problematic-sharding"
             },
             {
-              "id": "old",
-              "runs-on": "ubuntu-latest",
-              "args": "tests-old ARGS=--disable-problematic-sharding"
-            },
-            {
               "id": "single-cpu",
               "runs-on": "ubuntu-latest",
               "args": "tests ARGS=--num-cpu-devices=1 COVERAGE_SUFFIX=-single-cpu"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -337,6 +337,12 @@ jobs:
       - name: Update package version
         run: make copy-version
 
+      - name: Update locked dependencies
+        run: make update-deps
+
+      - name: Bump oldest supported dependencies
+        run: make update-oldest-deps
+
   required-dummy:
     runs-on: ubuntu-latest
     needs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,3 +61,11 @@ repos:
     rev: 0.11.7
     hooks:
       - id: uv-lock
+  - repo: local
+    hooks:
+      - id: check-workarounds
+        name: check stale WORKAROUND markers
+        entry: uv run --dev python config/check_workarounds.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ update-oldest-deps:
 	$(UV_RUN) python config/update_python_version.py --bump-date=$(BUMP_PYTHON_VERSION_DATE) --num-supported=$(NUM_SUPPORTED_PYTHON_RELEASES)
 	$(UV_RUN) python config/update_oldest_deps.py --min-old-date=$(OLD_DATE) --delay-days=$(OLD_DELAY_DAYS)
 	uv lock
+	@$(UV_RUN) python config/check_workarounds.py || echo "^^ some WORKAROUND(...) markers are now obsolete; please review and remove"
 
 .PHONY: copy-version
 copy-version: src/bartz/_version.py

--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,7 @@ setup:
 
 .PHONY: lint
 lint:
-	# the git config vars are a workaround for https://github.com/sbrunner/hooks/issues/374
-	# fixed in sbrunner/hooks v1.7.0
-	GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=log.showSignature GIT_CONFIG_VALUE_0=false $(UV_RUN) pre-commit run --all-files
+	$(UV_RUN) pre-commit run --all-files
 
 ################# TESTS #################
 

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,13 @@ help:
 	@echo "- ipython-old: start an ipython shell with oldest supported python and dependencies"
 	@echo "- lint: run pre-commit hooks on all files"
 	@echo
+	@echo "Update dependencies workflow:"
+	@echo "- new PR"
+	@echo "- $$ make update-deps"
+	@echo "- $$ make tests  # and debug"
+	@echo "- $$ make update-oldest-deps"
+	@echo "- $$ make tests-old  # and debug"
+	@echo
 	@echo "Release workflow:"
 	@echo "- do a PR that re-runs benchmarks"
 	@echo "- create a new branch"

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,12 @@ EXTRAS = $(if $(filter 12 13,$(CUDA_VERSION)),--extra=cuda$(CUDA_VERSION),)
 UV_RUN = uv run --dev $(EXTRAS)
 
 # define command to run python with oldest supported dependencies
-# OLD_DATE and OLD_DELAY_DAYS drive the `update-oldest-deps` policy.
+# OLD_DATE / OLD_DELAY_DAYS / BUMP_PYTHON_VERSION_DATE / NUM_SUPPORTED_PYTHON_RELEASES
+# drive the `update-oldest-deps` policy.
 OLD_DATE = 2025-05-15
 OLD_DELAY_DAYS = 365
+BUMP_PYTHON_VERSION_DATE = 10-31
+NUM_SUPPORTED_PYTHON_RELEASES = 5
 OLD_PYTHON = $(shell grep 'requires-python' pyproject.toml | sed 's/.*>=\([0-9.]*\).*/\1/')
 UV_RUN_OLD = $(UV_RUN) --python=$(OLD_PYTHON) --resolution=lowest-direct --exclude-newer=$(OLD_DATE) --isolated
 
@@ -169,6 +172,7 @@ update-deps:
 
 .PHONY: update-oldest-deps
 update-oldest-deps:
+	$(UV_RUN) python config/update_python_version.py --bump-date=$(BUMP_PYTHON_VERSION_DATE) --num-supported=$(NUM_SUPPORTED_PYTHON_RELEASES)
 	$(UV_RUN) python config/update_oldest_deps.py --min-old-date=$(OLD_DATE) --delay-days=$(OLD_DELAY_DAYS)
 	uv lock
 

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,11 @@ EXTRAS = $(if $(filter 12 13,$(CUDA_VERSION)),--extra=cuda$(CUDA_VERSION),)
 UV_RUN = uv run --dev $(EXTRAS)
 
 # define command to run python with oldest supported dependencies
+# OLD_DATE and OLD_DELAY_DAYS drive the `update-oldest-deps` policy.
+OLD_DATE = 2025-05-15
+OLD_DELAY_DAYS = 365
 OLD_PYTHON = $(shell grep 'requires-python' pyproject.toml | sed 's/.*>=\([0-9.]*\).*/\1/')
-UV_RUN_OLD = $(UV_RUN) --python=$(OLD_PYTHON) --resolution=lowest-direct --exclude-newer=2025-05-15 --isolated
+UV_RUN_OLD = $(UV_RUN) --python=$(OLD_PYTHON) --resolution=lowest-direct --exclude-newer=$(OLD_DATE) --isolated
 
 .PHONY: help
 help:
@@ -48,6 +51,7 @@ help:
 	@echo "- covreport: build html coverage report"
 	@echo "- covcheck: check coverage is above some thresholds"
 	@echo "- update-deps: remove .venv, upgrade uv.lock, update pre-commit hooks"
+	@echo "- update-oldest-deps: advance OLD_DATE and refresh oldest-supported pins in pyproject.toml"
 	@echo "- copy-version: sync version from pyproject.toml to _version.py"
 	@echo "- check-committed: verify there are no uncommitted changes"
 	@echo "- release: packages the python module, invokes tests and docs first"
@@ -162,6 +166,11 @@ covcheck:
 update-deps:
 	uv lock --upgrade
 	$(UV_RUN) pre-commit autoupdate
+
+.PHONY: update-oldest-deps
+update-oldest-deps:
+	$(UV_RUN) python config/update_oldest_deps.py --min-old-date=$(OLD_DATE) --delay-days=$(OLD_DELAY_DAYS)
+	uv lock
 
 .PHONY: copy-version
 copy-version: src/bartz/_version.py

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,6 @@ update-oldest-deps:
 	$(UV_RUN) python config/update_python_version.py --bump-date=$(BUMP_PYTHON_VERSION_DATE) --num-supported=$(NUM_SUPPORTED_PYTHON_RELEASES)
 	$(UV_RUN) python config/update_oldest_deps.py --min-old-date=$(OLD_DATE) --delay-days=$(OLD_DELAY_DAYS)
 	uv lock
-	@$(UV_RUN) python config/check_workarounds.py || echo "^^ some WORKAROUND(...) markers are now obsolete; please review and remove"
 
 .PHONY: copy-version
 copy-version: src/bartz/_version.py

--- a/config/check_workarounds.py
+++ b/config/check_workarounds.py
@@ -1,0 +1,140 @@
+# bartz/config/check_workarounds.py
+#
+# Copyright (c) 2026, The Bartz Contributors
+#
+# This file is part of bartz.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Report obsolete `WORKAROUND(pkg<ver)` / `WORKAROUND(pkg<=ver)` markers.
+
+A marker is obsolete given the current floors in pyproject.toml.
+
+Marker grammar:
+    WORKAROUND(<pkg><op><version>): <free-text>
+with <op> in {<, <=}. A marker is obsolete iff every supported version of
+<pkg> (i.e., versions >= the lower bound in pyproject.toml) satisfies NOT
+(version <op> <version>).
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import tomli
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+MARKER_RE = re.compile(r'WORKAROUND\(\s*([A-Za-z0-9_.\-]+)\s*(<=|<)\s*([^)\s]+)\s*\)')
+
+
+def floors_from_pyproject(path: Path) -> dict[str, Version]:
+    """Return {normalized_pkg_name: lower_bound_version} from pyproject.toml."""
+    data = tomli.loads(path.read_text())
+    reqs: list[str] = list(data.get('project', {}).get('dependencies', []))
+    for group in data.get('dependency-groups', {}).values():
+        reqs.extend(group)
+    floors: dict[str, Version] = {}
+    for r in reqs:
+        req = Requirement(r)
+        lb = _lower_bound(req.specifier)
+        if lb is None:
+            continue
+        name = req.name.lower()
+        # Take the max: later constraints (e.g. dev-group) only tighten the floor.
+        if name not in floors or lb > floors[name]:
+            floors[name] = lb
+    return floors
+
+
+def _lower_bound(spec: SpecifierSet) -> Version | None:
+    for s in spec:
+        if s.operator in ('>=', '==', '~='):
+            try:
+                return Version(s.version)
+            except InvalidVersion:
+                return None
+    return None
+
+
+def is_obsolete(op: str, bound: Version, floor: Version) -> bool:
+    """Check whether a `version <op> bound` workaround is obsolete.
+
+    It is obsolete when no supported version (>= floor) can satisfy the
+    condition.
+    """
+    if op == '<':
+        return floor >= bound
+    if op == '<=':
+        return floor > bound
+    raise ValueError(op)
+
+
+def scan(root: Path) -> list[tuple[str, str, str]]:
+    """Return grep matches `(file, lineno, line)` for WORKAROUND markers."""
+    result = subprocess.run(
+        ['git', 'grep', '--no-color', '-nI', '-E', r'WORKAROUND\([^)]*(<|<=)[^)]*\)'],  # noqa: S607
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    matches = []
+    for line in result.stdout.splitlines():
+        f, n, rest = line.split(':', 2)
+        if Path(f).resolve() == Path(__file__).resolve():
+            continue  # skip this script's own grammar docs
+        matches.append((f, n, rest))
+    return matches
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    floors = floors_from_pyproject(root / 'pyproject.toml')
+    stale: list[str] = []
+    unknown: list[str] = []
+    for file, lineno, text in scan(root):
+        m = MARKER_RE.search(text)
+        if not m:
+            continue
+        pkg, op, ver = m.group(1).lower(), m.group(2), m.group(3)
+        try:
+            bound = Version(ver)
+        except InvalidVersion:
+            unknown.append(f'{file}:{lineno}: bad version in marker: {text.strip()}')
+            continue
+        floor = floors.get(pkg)
+        if floor is None:
+            unknown.append(f'{file}:{lineno}: {pkg!r} not pinned in pyproject.toml')
+            continue
+        if is_obsolete(op, bound, floor):
+            stale.append(
+                f'{file}:{lineno}: {pkg}{op}{ver} is obsolete (floor={floor}) | {text.strip()}'
+            )
+    for line in unknown:
+        print(f'WARN  {line}', file=sys.stderr)
+    for line in stale:
+        print(f'STALE {line}', file=sys.stderr)
+    return 1 if stale else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/config/update_oldest_deps.py
+++ b/config/update_oldest_deps.py
@@ -42,7 +42,7 @@ from pathlib import Path
 
 import tomli
 from packaging.requirements import Requirement
-from packaging.specifiers import SpecifierSet
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
 PYPI_URL = 'https://pypi.org/pypi/{name}/json'
@@ -113,8 +113,38 @@ def earliest_upload(files: list[dict]) -> datetime.datetime | None:
     return min(times) if times else None
 
 
-def latest_before(name: str, cutoff: datetime.date) -> Version | None:
-    """Latest final release of `name` whose earliest upload is < cutoff."""
+def release_supports_python(files: list[dict], oldest_python: Version) -> bool:
+    """Check Python compatibility of a release.
+
+    Return True iff any non-yanked file's `requires_python` accepts
+    `oldest_python`. Files with no `requires_python` metadata are treated as
+    universally compatible (common for old releases predating PEP 345).
+    """
+    any_non_yanked = False
+    for f in files:
+        if f.get('yanked'):
+            continue
+        any_non_yanked = True
+        spec_str = f.get('requires_python')
+        if not spec_str:
+            return True
+        try:
+            spec = SpecifierSet(spec_str)
+        except InvalidSpecifier:
+            return True
+        if spec.contains(str(oldest_python), prereleases=True):
+            return True
+    return not any_non_yanked
+
+
+def latest_before(
+    name: str, cutoff: datetime.date, oldest_python: Version
+) -> Version | None:
+    """Return the latest final release of `name` matching the constraints.
+
+    The release must have earliest upload strictly before `cutoff` and must
+    support `oldest_python`.
+    """
     data = fetch_pypi(name)
     cutoff_dt = datetime.datetime.combine(
         cutoff, datetime.time.min, tzinfo=datetime.timezone.utc
@@ -132,8 +162,11 @@ def latest_before(name: str, cutoff: datetime.date) -> Version | None:
         upload = earliest_upload(files)
         if upload is None:
             continue
-        if upload < cutoff_dt:
-            candidates.append(v)
+        if upload >= cutoff_dt:
+            continue
+        if not release_supports_python(files, oldest_python):
+            continue
+        candidates.append(v)
     return max(candidates) if candidates else None
 
 
@@ -191,7 +224,7 @@ def update_makefile_old_date(makefile_path: Path, new_date: datetime.date) -> bo
     return True
 
 
-def main() -> int:
+def main() -> int:  # noqa: C901, PLR0915
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         '--min-old-date',
@@ -213,6 +246,19 @@ def main() -> int:
     with args.pyproject.open('rb') as f:
         pyproject = tomli.load(f)
 
+    requires_python = pyproject.get('project', {}).get('requires-python')
+    if not requires_python:
+        msg = 'project.requires-python missing from pyproject.toml'
+        raise RuntimeError(msg)
+    rp_spec = SpecifierSet(requires_python)
+    oldest_python = next(
+        (Version(s.version) for s in rp_spec if s.operator in ('>=', '==', '~=')), None
+    )
+    if oldest_python is None:
+        msg = f'cannot derive oldest Python from requires-python={requires_python!r}'
+        raise RuntimeError(msg)
+    print(f'oldest supported Python: {oldest_python}')
+
     raw_reqs = collect_requirements(pyproject)
     # Deduplicate while preserving order (a dep may appear in multiple groups).
     seen: set[str] = set()
@@ -231,7 +277,7 @@ def main() -> int:
             continue
         floor = current_lower_bound(req.specifier)
         try:
-            pypi_cand = latest_before(req.name, new_old_date)
+            pypi_cand = latest_before(req.name, new_old_date, oldest_python)
         except Exception as e:  # noqa: BLE001
             rows.append((req.name, 'error', str(e)))
             continue

--- a/config/update_oldest_deps.py
+++ b/config/update_oldest_deps.py
@@ -1,0 +1,272 @@
+# bartz/config/update_oldest_deps.py
+#
+# Copyright (c) 2026, The Bartz Contributors
+#
+# This file is part of bartz.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Refresh oldest-supported dependency pins per the OLD_DATE policy.
+
+Computes a new OLD_DATE as max(today - delay_days, min_old_date), queries PyPI
+for each dependency declared in pyproject.toml, picks the latest final release
+whose earliest file upload is strictly before OLD_DATE, and rewrites the
+lower bounds in pyproject.toml and the OLD_DATE line in the Makefile.
+Bounds only move forward: per-dep, the chosen version is max(pypi_candidate,
+current lower bound).
+"""
+
+import argparse
+import datetime
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+import tomli
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+PYPI_URL = 'https://pypi.org/pypi/{name}/json'
+
+
+def parse_date(s: str) -> datetime.date:
+    return (
+        datetime.datetime.strptime(s, '%Y-%m-%d')
+        .replace(tzinfo=datetime.timezone.utc)
+        .date()
+    )
+
+
+def compute_old_date(min_old_date: datetime.date, delay_days: int) -> datetime.date:
+    today = datetime.datetime.now(tz=datetime.timezone.utc).date()
+    return max(today - datetime.timedelta(days=delay_days), min_old_date)
+
+
+def collect_requirements(pyproject: dict) -> list[str]:
+    """Return every requirement string declared in pyproject.toml."""
+    reqs: list[str] = []
+    reqs.extend(pyproject.get('project', {}).get('dependencies', []))
+    for extra_reqs in (
+        pyproject.get('project', {}).get('optional-dependencies', {}).values()
+    ):
+        reqs.extend(extra_reqs)
+    for group_reqs in pyproject.get('dependency-groups', {}).values():
+        reqs.extend(group_reqs)
+    return reqs
+
+
+def current_lower_bound(spec: SpecifierSet) -> Version | None:
+    for s in spec:
+        if s.operator in ('>=', '==', '~='):
+            try:
+                return Version(s.version)
+            except InvalidVersion:
+                return None
+    return None
+
+
+def fetch_pypi(name: str) -> dict:
+    url = PYPI_URL.format(name=name)
+    if not url.startswith('https://'):
+        msg = f'refusing non-https URL: {url}'
+        raise ValueError(msg)
+    with urllib.request.urlopen(url, timeout=30) as resp:  # noqa: S310
+        return json.load(resp)
+
+
+def earliest_upload(files: list[dict]) -> datetime.datetime | None:
+    times = []
+    for f in files:
+        if f.get('yanked'):
+            continue
+        t = f.get('upload_time_iso_8601') or f.get('upload_time')
+        if not t:
+            continue
+        # strip trailing 'Z' and optional fractional seconds handled by fromisoformat in 3.11+
+        t = t.replace('Z', '+00:00')
+        try:
+            dt = datetime.datetime.fromisoformat(t)
+        except ValueError:
+            continue
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        times.append(dt)
+    return min(times) if times else None
+
+
+def latest_before(name: str, cutoff: datetime.date) -> Version | None:
+    """Latest final release of `name` whose earliest upload is < cutoff."""
+    data = fetch_pypi(name)
+    cutoff_dt = datetime.datetime.combine(
+        cutoff, datetime.time.min, tzinfo=datetime.timezone.utc
+    )
+    candidates: list[Version] = []
+    for vstr, files in data.get('releases', {}).items():
+        try:
+            v = Version(vstr)
+        except InvalidVersion:
+            continue
+        if v.is_prerelease or v.is_devrelease:
+            continue
+        if not files:
+            continue
+        upload = earliest_upload(files)
+        if upload is None:
+            continue
+        if upload < cutoff_dt:
+            candidates.append(v)
+    return max(candidates) if candidates else None
+
+
+def format_spec(req: Requirement, version: Version) -> str:
+    extras = f'[{",".join(sorted(req.extras))}]' if req.extras else ''
+    return f'{req.name}{extras}>={version}'
+
+
+def replace_requirement_line(
+    text: str, old_req_str: str, new_req_str: str
+) -> tuple[str, bool]:
+    """Replace a quoted requirement literal in pyproject.toml text.
+
+    Matches either single- or double-quoted form of the exact old string.
+    """
+    if old_req_str == new_req_str:
+        return text, False
+    replaced = False
+    for quote in ('"', "'"):
+        old_lit = f'{quote}{old_req_str}{quote}'
+        new_lit = f'{quote}{new_req_str}{quote}'
+        if old_lit in text:
+            text = text.replace(old_lit, new_lit, 1)
+            replaced = True
+            break
+    return text, replaced
+
+
+def update_pyproject(pyproject_path: Path, updates: list[tuple[str, str]]) -> int:
+    text = pyproject_path.read_text()
+    changed = 0
+    for old, new in updates:
+        text, did = replace_requirement_line(text, old, new)
+        if did:
+            changed += 1
+        elif old != new:
+            print(
+                f'warning: could not locate {old!r} in pyproject.toml', file=sys.stderr
+            )
+    pyproject_path.write_text(text)
+    return changed
+
+
+def update_makefile_old_date(makefile_path: Path, new_date: datetime.date) -> bool:
+    text = makefile_path.read_text()
+    pattern = re.compile(r'^OLD_DATE\s*=\s*\S+\s*$', re.MULTILINE)
+    new_line = f'OLD_DATE = {new_date.isoformat()}'
+    new_text, n = pattern.subn(new_line, text, count=1)
+    if n == 0:
+        msg = 'OLD_DATE assignment not found in Makefile'
+        raise RuntimeError(msg)
+    if new_text == text:
+        return False
+    makefile_path.write_text(new_text)
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--min-old-date',
+        required=True,
+        type=parse_date,
+        help='YYYY-MM-DD; floor for the new OLD_DATE.',
+    )
+    parser.add_argument(
+        '--delay-days', required=True, type=int, help='Target lag behind today in days.'
+    )
+    parser.add_argument('--pyproject', type=Path, default=Path('pyproject.toml'))
+    parser.add_argument('--makefile', type=Path, default=Path('Makefile'))
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args()
+
+    new_old_date = compute_old_date(args.min_old_date, args.delay_days)
+    print(f'OLD_DATE: {args.min_old_date.isoformat()} -> {new_old_date.isoformat()}')
+
+    with args.pyproject.open('rb') as f:
+        pyproject = tomli.load(f)
+
+    raw_reqs = collect_requirements(pyproject)
+    # Deduplicate while preserving order (a dep may appear in multiple groups).
+    seen: set[str] = set()
+    reqs: list[str] = []
+    for r in raw_reqs:
+        if r not in seen:
+            seen.add(r)
+            reqs.append(r)
+
+    updates: list[tuple[str, str]] = []
+    rows: list[tuple[str, str, str]] = []
+    for req_str in reqs:
+        req = Requirement(req_str)
+        if req.url or req.marker:
+            rows.append((req.name, 'skipped', 'has url/marker'))
+            continue
+        floor = current_lower_bound(req.specifier)
+        try:
+            pypi_cand = latest_before(req.name, new_old_date)
+        except Exception as e:  # noqa: BLE001
+            rows.append((req.name, 'error', str(e)))
+            continue
+        if pypi_cand is None and floor is None:
+            rows.append(
+                (req.name, 'skipped', 'no eligible version and no existing floor')
+            )
+            continue
+        chosen = max(v for v in (pypi_cand, floor) if v is not None)
+        new_req_str = format_spec(req, chosen)
+        if new_req_str != req_str:
+            updates.append((req_str, new_req_str))
+        rows.append((req.name, str(floor) if floor else '-', str(chosen)))
+
+    col1 = max((len(r[0]) for r in rows), default=4)
+    col2 = max((len(r[1]) for r in rows), default=4)
+    print()
+    print(f'{"dep".ljust(col1)}  {"from".ljust(col2)}  to')
+    print(f'{"-" * col1}  {"-" * col2}  --')
+    for name, old, new in rows:
+        print(f'{name.ljust(col1)}  {old.ljust(col2)}  {new}')
+    print()
+
+    if args.dry_run:
+        print(
+            f'dry-run: {len(updates)} pyproject edit(s), OLD_DATE target {new_old_date.isoformat()}'
+        )
+        return 0
+
+    n_py = update_pyproject(args.pyproject, updates)
+    mk_changed = update_makefile_old_date(args.makefile, new_old_date)
+    print(f'pyproject.toml: {n_py} line(s) updated')
+    print(f'Makefile OLD_DATE: {"updated" if mk_changed else "unchanged"}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/config/update_python_version.py
+++ b/config/update_python_version.py
@@ -1,0 +1,183 @@
+# bartz/config/update_python_version.py
+#
+# Copyright (c) 2026, The Bartz Contributors
+#
+# This file is part of bartz.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Update the supported Python version range.
+
+Policy:
+- A new Python minor is adopted each year on BUMP_PYTHON_VERSION_DATE (MM-DD).
+- We support the most recent `num_supported` minor releases.
+- Anchor: in ANCHOR_YEAR (2026), before the bump date of that year, the latest
+  supported Python minor is ANCHOR_LATEST_MINOR (14). One bump = +1 minor.
+- Non-regression: neither the requires-python floor nor the pinned latest
+  Python version ever moves backward.
+
+Outputs:
+- Rewrites `requires-python = ">=3.<oldest>"` in pyproject.toml.
+- Rewrites .python-version to `3.<latest>`.
+"""
+
+import argparse
+import datetime
+import re
+import sys
+from pathlib import Path
+
+import tomli
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+ANCHOR_YEAR = 2026
+ANCHOR_LATEST_MINOR = 14  # latest Python = 3.14 in 2026 before the bump date
+
+
+def parse_bump_date(s: str) -> tuple[int, int]:
+    m = re.fullmatch(r'(\d{1,2})-(\d{1,2})', s)
+    if not m:
+        msg = f'invalid --bump-date {s!r}, expected MM-DD'
+        raise argparse.ArgumentTypeError(msg)
+    month, day = int(m.group(1)), int(m.group(2))
+    datetime.date(2000, month, day)  # validate
+    return month, day
+
+
+def compute_latest_minor(
+    today: datetime.date, bump: tuple[int, int], anchor_year: int, anchor_latest: int
+) -> int:
+    bumps = today.year - anchor_year
+    if (today.month, today.day) >= bump:
+        bumps += 1
+    return anchor_latest + bumps
+
+
+def read_requires_python_floor(pyproject: dict) -> Version | None:
+    spec_str = pyproject.get('project', {}).get('requires-python')
+    if not spec_str:
+        return None
+    spec = SpecifierSet(spec_str)
+    for s in spec:
+        if s.operator in ('>=', '==', '~='):
+            return Version(s.version)
+    return None
+
+
+def read_pinned_python(path: Path) -> Version | None:
+    if not path.exists():
+        return None
+    content = path.read_text().strip()
+    if not content:
+        return None
+    return Version(content.splitlines()[0].strip())
+
+
+def update_requires_python(path: Path, new_floor: Version) -> bool:
+    text = path.read_text()
+    pattern = re.compile(r'^(requires-python\s*=\s*)"[^"]*"', re.MULTILINE)
+    new_line = f'requires-python = ">=3.{new_floor.minor}"'
+
+    def repl(_m: re.Match[str]) -> str:
+        return new_line
+
+    new_text, n = pattern.subn(repl, text, count=1)
+    if n == 0:
+        msg = 'requires-python assignment not found in pyproject.toml'
+        raise RuntimeError(msg)
+    if new_text == text:
+        return False
+    path.write_text(new_text)
+    return True
+
+
+def update_python_version_file(path: Path, new_latest: Version) -> bool:
+    new_content = f'3.{new_latest.minor}\n'
+    old_content = path.read_text() if path.exists() else ''
+    if old_content == new_content:
+        return False
+    path.write_text(new_content)
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--bump-date',
+        required=True,
+        type=parse_bump_date,
+        help='MM-DD; day of year on which a new Python minor is adopted.',
+    )
+    parser.add_argument(
+        '--num-supported',
+        required=True,
+        type=int,
+        help='How many consecutive Python minors to support.',
+    )
+    parser.add_argument('--pyproject', type=Path, default=Path('pyproject.toml'))
+    parser.add_argument(
+        '--python-version-file', type=Path, default=Path('.python-version')
+    )
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args()
+
+    today = datetime.datetime.now(tz=datetime.timezone.utc).date()
+    latest_minor = compute_latest_minor(
+        today, args.bump_date, ANCHOR_YEAR, ANCHOR_LATEST_MINOR
+    )
+    oldest_minor = latest_minor - (args.num_supported - 1)
+
+    with args.pyproject.open('rb') as f:
+        pyproject = tomli.load(f)
+    current_floor = read_requires_python_floor(pyproject)
+    current_pinned = read_pinned_python(args.python_version_file)
+
+    computed_floor = Version(f'3.{oldest_minor}')
+    computed_latest = Version(f'3.{latest_minor}')
+    new_floor = max(computed_floor, current_floor) if current_floor else computed_floor
+    new_latest = (
+        max(computed_latest, current_pinned) if current_pinned else computed_latest
+    )
+
+    print(
+        f'Python policy: today={today.isoformat()} -> '
+        f'computed range 3.{oldest_minor}..3.{latest_minor}'
+    )
+    print(
+        f'requires-python floor: {current_floor} -> {new_floor} '
+        f'({"unchanged" if current_floor == new_floor else "advanced"})'
+    )
+    print(
+        f'.python-version: {current_pinned} -> {new_latest} '
+        f'({"unchanged" if current_pinned == new_latest else "advanced"})'
+    )
+
+    if args.dry_run:
+        return 0
+
+    py_changed = update_requires_python(args.pyproject, new_floor)
+    pv_changed = update_python_version_file(args.python_version_file, new_latest)
+    print(f'pyproject.toml requires-python: {"updated" if py_changed else "unchanged"}')
+    print(f'.python-version: {"updated" if pv_changed else "unchanged"}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,12 +87,11 @@ extensions = [
     'myst_nb',  # markdown + jupyter notebook support
 ]
 
-# Workaround for sphinx-autodoc-typehints bug on Python 3.14: Union type aliases
+# WORKAROUND(sphinx-autodoc-typehints<3.10.0): on Python 3.14 Union type aliases
 # (like jax.typing.DTypeLike = str | ...) have __module__='typing' and
 # __qualname__='Union', so build_type_mapping() creates a bogus mapping
 # typing.Union -> jax.typing.DTypeLike, rendering every Union as DTypeLike[...].
-# https://github.com/tox-dev/sphinx-autodoc-typehints/issues/677
-# fixed in sphinx-autodoc-typehints 3.10.0
+# See https://github.com/tox-dev/sphinx-autodoc-typehints/issues/677.
 if sys.version_info >= (3, 14):
     import importlib as _importlib
     import types as _types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,9 +228,6 @@ ignore = [
     "SLF001", # Private member accessed: `*`
     "TID253", # `{module}` is banned at the module level
 ]
-"docs/conf.py" = [
-    "S607", # Starting a process with a partial executable path. Ignored because for a build script it makes more sense to use PATH.
-]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,15 +36,15 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "equinox>=0.12.2",
-    "jax>=0.5.3",
+    "jax>=0.6.0",
     "jaxtyping>=0.3.2",
-    "numpy>=1.25.2",
-    "scipy>=1.11.4",
+    "numpy>=2.2.5",
+    "scipy>=1.15.3",
 ]
 
 [project.optional-dependencies]
-cuda12 = ["jax[cuda12]"]
-cuda13 = ["jax[cuda13]"]
+cuda12 = ["jax[cuda12]>=0.6.0"]
+cuda13 = ["jax[cuda13]>=0.6.0"]
 
 [project.urls]
 Homepage = "https://github.com/bartz-org/bartz"
@@ -58,14 +58,14 @@ dev = [
     "matplotlib>=3.10.3",
     "matplotlib-label-lines>=0.8.1",
     "pre-commit>=4.2.0",
-    "rich>=13.9.4",
+    "rich>=14.0.0",
     "snakeviz>=2.2.2",
     "tqdm>=4.67.1",
     "virtualenv>=20.31.2",
     "asv>=0.6.4",
     "beartype>=0.20.2",
     "flaky>=3.8.1",
-    "gitpython>=3.1.43",
+    "gitpython>=3.1.44",
     "packaging>=25.0",
     "polars[pandas,pyarrow]>=1.29.0",
     "pytest>=8.3.5",

--- a/src/bartz/grove/_grove.py
+++ b/src/bartz/grove/_grove.py
@@ -33,11 +33,7 @@ from equinox import Module
 from jax import jit, lax, vmap
 from jax import numpy as jnp
 from jaxtyping import Array, Bool, Float32, Int32, Shaped, UInt
-
-try:
-    from numpy.lib.array_utils import normalize_axis_tuple  # numpy 2
-except ImportError:
-    from numpy.core.numeric import normalize_axis_tuple  # numpy 1
+from numpy.lib.array_utils import normalize_axis_tuple
 
 from bartz.jaxext import autobatch, minimal_unsigned_dtype, vmap_nodoc
 

--- a/src/bartz/jaxext/__init__.py
+++ b/src/bartz/jaxext/__init__.py
@@ -29,8 +29,9 @@ from collections.abc import Callable, Sequence
 from functools import partial
 from typing import Any
 
+# WORKAROUND(jax<0.6.1): shard_map was promoted from jax.experimental to top-level in 0.6.1
 try:
-    from jax import shard_map  # available since jax v0.6.1
+    from jax import shard_map
 except ImportError:
     from jax.experimental.shard_map import shard_map
 
@@ -280,8 +281,7 @@ def jit_active() -> bool:
 
 def _equal_shards(x: Array, axis_name: str) -> Bool[Array, '']:
     """Check if all shards of `x` are equal, to be used in a `shard_map` context."""
-    # get axis size, this could be `size = lax.axis_size(axis_name)`, but it's
-    # supported only since jax v0.6.1
+    # WORKAROUND(jax<0.6.1): could be `size = lax.axis_size(axis_name)`
     mesh = typeof(x).sharding.mesh
     i = mesh.axis_names.index(axis_name)
     size = mesh.axis_sizes[i]

--- a/src/bartz/jaxext/_autobatch.py
+++ b/src/bartz/jaxext/_autobatch.py
@@ -30,16 +30,11 @@ from functools import partial, wraps
 from typing import Any
 from warnings import warn
 
-from jax.typing import DTypeLike
-
-try:
-    from numpy.lib.array_utils import normalize_axis_index  # numpy 2
-except ImportError:
-    from numpy.core.numeric import normalize_axis_index  # numpy 1
-
 from jax import ShapeDtypeStruct, eval_shape, jit, lax, tree
 from jax import numpy as jnp
+from jax.typing import DTypeLike
 from jaxtyping import Array, PyTree, Shaped
+from numpy.lib.array_utils import normalize_axis_index
 
 
 def expand_axes(axes: PyTree[int | None], tree_arg: PyTree) -> PyTree[int | None]:

--- a/src/bartz/mcmcstep/_state.py
+++ b/src/bartz/mcmcstep/_state.py
@@ -1021,8 +1021,8 @@ def _parse_mesh(
         assert 'chains' not in mesh.axis_names
 
     # check the axes we use are in auto mode
-    assert 'chains' not in mesh.axis_names or 'chains' in _auto_axes(mesh)
-    assert 'data' not in mesh.axis_names or 'data' in _auto_axes(mesh)
+    assert 'chains' not in mesh.axis_names or 'chains' in mesh.auto_axes
+    assert 'data' not in mesh.axis_names or 'data' in mesh.auto_axes
 
     return mesh
 
@@ -1051,16 +1051,6 @@ def _parse_target_platform(
     else:
         assert target_platform is None, 'target_platform not used, unset it'
         return target_platform
-
-
-def _auto_axes(mesh: Mesh) -> list[str]:
-    """Re-implement `Mesh.auto_axes` because that's missing in jax v0.5."""
-    # Mesh.auto_axes added in jax v0.6.0
-    return [
-        n
-        for n, t in zip(mesh.axis_names, mesh.axis_types, strict=True)
-        if t == AxisType.Auto
-    ]
 
 
 @partial(filter_jit, donate='all')

--- a/src/bartz/mcmcstep/_step.py
+++ b/src/bartz/mcmcstep/_step.py
@@ -27,11 +27,10 @@
 from dataclasses import replace
 from functools import partial
 
+# WORKAROUND(jax<0.6.1): shard_map was promoted from jax.experimental to top-level in 0.6.1
 try:
-    # available since jax v0.6.1
     from jax import shard_map
 except ImportError:
-    # deprecated in jax v0.8.0
     from jax.experimental.shard_map import shard_map
 
 import jax
@@ -1144,8 +1143,8 @@ def _scatter_add(
 
 
 def _get_shard_map_patch_kwargs() -> dict[str, bool]:
-    # see jax/issues/#34249, problem with vmap(shard_map(psum))
-    # we tried the config jax_disable_vmap_shmap_error but it didn't work
+    # WORKAROUND(jax<=0.8.2): vmap(shard_map(psum)), jax#34249; the
+    # jax_disable_vmap_shmap_error config did not work
     if jax.__version__ in ('0.8.1', '0.8.2'):
         return {'check_vma': False}
     else:

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1491,6 +1491,7 @@ def run_bart_and_block(bkw: BartKW, keys: split) -> None:
 @contextmanager
 def array_garbage_collection_guard(value: str) -> Iterator[None]:
     """Implement `jax.array_garbage_collection_guard`, added in jax v0.9.1."""
+    # WORKAROUND(jax<0.9.1): replace with `jax.array_garbage_collection_guard`
     setting = 'jax_array_garbage_collection_guard'
     prev = getattr(config, setting)
     config.update(setting, value)

--- a/tests/test_jaxext.py
+++ b/tests/test_jaxext.py
@@ -29,8 +29,9 @@ from inspect import signature
 from itertools import product
 from warnings import catch_warnings
 
+# WORKAROUND(jax<0.6.1): shard_map was promoted from jax.experimental to top-level in 0.6.1
 try:
-    from jax import shard_map  # available since jax v0.6.1
+    from jax import shard_map
 except ImportError:
     from jax.experimental.shard_map import shard_map
 
@@ -404,6 +405,7 @@ class TestJaxPatches:
         x1 = invgamma.ppf(p, alpha)
         assert_allclose(x1, x0, rtol=1e-6)
 
+    # WORKAROUND(jax<0.6.2): ndtri bug
     @pytest.mark.xfail(reason='Fixed in jax 0.6.2.')
     def test_ndtri_bugged(self, keys: split) -> None:
         """Check that `jax.scipy.special.ndtri` triggers `jax.debug_infs`."""
@@ -531,9 +533,9 @@ def make_broken_replicated_array(x: Array, axis_name: str, mesh: Mesh) -> Array:
 
 def _get_check_vma_false_kwargs() -> dict[str, bool]:
     """Get `dict(check_vma=False)` or the equivalent for old jax versions."""
+    # WORKAROUND(jax<0.6.1): check_rep was renamed to check_vma in 0.6.1
     sig = signature(shard_map)
     if 'check_vma' in sig.parameters:
-        # since jax v0.6.1
         return dict(check_vma=False)
     else:
         return dict(check_rep=False)

--- a/tests/test_mcmcstep.py
+++ b/tests/test_mcmcstep.py
@@ -911,9 +911,9 @@ def check_same_structure(x: PyTree, y: PyTree) -> None:
     def check(_path: KeyPath, x: Array, y: Array) -> None:
         assert x.shape == y.shape
         assert x.dtype == y.dtype
-        if jax.__version_info__ >= (0, 6, 0):
-            # not actually know if this will work properly in 0.6.0
-            assert x.sharding.is_equivalent_to(y.sharding, x.ndim)
+        assert x.sharding.is_equivalent_to(y.sharding, x.ndim) or (
+            x.size == 0 and jax.__version_info__ < (0, 6, 1)
+        )
 
     tree.map_with_path(check, x, y)
 

--- a/tests/test_mcmcstep.py
+++ b/tests/test_mcmcstep.py
@@ -911,6 +911,7 @@ def check_same_structure(x: PyTree, y: PyTree) -> None:
     def check(_path: KeyPath, x: Array, y: Array) -> None:
         assert x.shape == y.shape
         assert x.dtype == y.dtype
+        # WORKAROUND(jax<0.6.1): empty-array sharding equivalence bug
         assert x.sharding.is_equivalent_to(y.sharding, x.ndim) or (
             x.size == 0 and jax.__version_info__ < (0, 6, 1)
         )

--- a/uv.lock
+++ b/uv.lock
@@ -283,12 +283,12 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "equinox", specifier = ">=0.12.2" },
-    { name = "jax", specifier = ">=0.5.3" },
-    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'" },
-    { name = "jax", extras = ["cuda13"], marker = "extra == 'cuda13'" },
+    { name = "jax", specifier = ">=0.6.0" },
+    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.6.0" },
+    { name = "jax", extras = ["cuda13"], marker = "extra == 'cuda13'", specifier = ">=0.6.0" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
-    { name = "numpy", specifier = ">=1.25.2" },
-    { name = "scipy", specifier = ">=1.11.4" },
+    { name = "numpy", specifier = ">=2.2.5" },
+    { name = "scipy", specifier = ">=1.15.3" },
 ]
 provides-extras = ["cuda12", "cuda13"]
 
@@ -298,7 +298,7 @@ dev = [
     { name = "asv", specifier = ">=0.6.4" },
     { name = "beartype", specifier = ">=0.20.2" },
     { name = "flaky", specifier = ">=3.8.1" },
-    { name = "gitpython", specifier = ">=3.1.43" },
+    { name = "gitpython", specifier = ">=3.1.44" },
     { name = "ipython", specifier = ">=8.36.0" },
     { name = "jupyterlab", specifier = ">=4.4.2" },
     { name = "matplotlib", specifier = ">=3.10.3" },
@@ -312,7 +312,7 @@ dev = [
     { name = "pytest-subtests", specifier = ">=0.14.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
-    { name = "rich", specifier = ">=13.9.4" },
+    { name = "rich", specifier = ">=14.0.0" },
     { name = "rpy2", specifier = ">=3.5.17" },
     { name = "snakeviz", specifier = ">=2.2.2" },
     { name = "sphinx", specifier = ">=8.1.3" },
@@ -2825,7 +2825,7 @@ name = "nvidia-cublas"
 version = "13.4.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/48/8571e55aaabbd112f06a39a71fbc3abf0b8a0d450921816a13a6d5e8fa0b/nvidia_cublas-13.4.0.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:705d7d214fbb20f134415ecadc488abf74f444c155a6555dec5687404afb18a9", size = 513051304, upload-time = "2026-04-13T09:49:32.758Z" },
@@ -2837,7 +2837,7 @@ name = "nvidia-cublas-cu12"
 version = "12.9.2.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc-cu12" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/a2/c96163a0fff1839c0c9548bbdeae7b853b867009e33b9b9264adc238b1cf/nvidia_cublas_cu12-12.9.2.10-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:5572131a59c3eebeeb1c4c8144f772d49372c20124916e072a0e3fc30df421d5", size = 575012079, upload-time = "2026-04-08T18:51:47.303Z" },
@@ -2897,9 +2897,9 @@ name = "nvidia-cuda-nvcc"
 version = "13.2.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-crt", marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cuda-runtime", marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-nvvm", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cuda-crt", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-runtime", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvvm", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/df/faf551572ae1359290afa5cb05d2c4b7e6674b07b8283b20eab4dbad15f6/nvidia_cuda_nvcc-13.2.78-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:dfc76950c775cd00ce588f15192f08c9b858c0dcfa7da685acf39a3d0d8f588b", size = 38713559, upload-time = "2026-04-13T09:42:17.478Z" },
@@ -2959,7 +2959,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.21.0.82"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/e9/aea85c214a5dad046e56131428c22ff40d0359db3a930040698c0c6c8e68/nvidia_cudnn_cu12-9.21.0.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:8ba7c5067854d2b8d8dc21a65bbc5a642b31e4dddc8864cf3a093d25a92e874c", size = 759281118, upload-time = "2026-04-14T15:30:44.958Z" },
@@ -2972,7 +2972,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.21.0.82"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cublas", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/57/5cf9fcddae153e529d8d5f9c33b98888e30053aa1a5c3ae555898d6dac50/nvidia_cudnn_cu13-9.21.0.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:d7c5b829970f5acf75d752fc33b6b697ae0c8a6f1fb4720e9244a709515c49cd", size = 513345481, upload-time = "2026-04-14T15:31:20.201Z" },
@@ -2984,7 +2984,7 @@ name = "nvidia-cufft"
 version = "12.2.0.46"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/b1/6e36381739b51e692d91646298ad5685c562929b899331c2bb6e9722a176/nvidia_cufft-12.2.0.46-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e8f3a22c2745f95327b7639ba2868ea2cbd5d3131ebe6313394e24164054f41", size = 218244743, upload-time = "2026-04-13T09:51:24.75Z" },
@@ -2996,7 +2996,7 @@ name = "nvidia-cufft-cu12"
 version = "11.4.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
@@ -3009,9 +3009,9 @@ name = "nvidia-cusolver"
 version = "12.2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-cusparse", marker = "python_full_version >= '3.11'" },
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cublas", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/21/21e5c491a8285a6ed039cbb8c60ec13ff3aff60c669e1caa4adaeb71f997/nvidia_cusolver-12.2.0.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9def09fcf300b9465cdf800142abf10149df28c4290bdf9e7b4a700480d31d7", size = 249744985, upload-time = "2026-04-13T09:54:33.757Z" },
@@ -3023,9 +3023,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.5.82"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
@@ -3038,7 +3038,7 @@ name = "nvidia-cusparse"
 version = "12.7.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/09/9f1fa88dd305e838b71f2ca4e50064e7cbdf2e15cd6410d9e1b74066cc41/nvidia_cusparse-12.7.10.1-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80cc98b38fdcf054a80bd9782fe2e63c66f90e202cac269f641357ccac5fe7e3", size = 168860233, upload-time = "2026-04-13T09:55:48.891Z" },
@@ -3050,7 +3050,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.10.65"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/6f/8710fbd17cdd1d0fc3fea7d36d5b65ce1933611c31e1861da330206b253a/nvidia_cusparse_cu12-12.5.10.65-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:221c73e7482dd93eda44e65ce567c031c07e2f93f6fa0ecd3ba876a195023e83", size = 366359408, upload-time = "2025-06-05T20:07:42.501Z" },
@@ -3100,7 +3100,7 @@ name = "nvidia-nvshmem-cu12"
 version = "3.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-cccl-cu12" },
+    { name = "nvidia-cuda-cccl-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/da/bd8ae5201f8c5751ece31fe4fe489ece10fbcf5fcc1a595855b6459b6d6e/nvidia_nvshmem_cu12-3.6.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7b38521ff84cdfc68da3360fe249cfbabfe05ee9aa271458857476124b03a420", size = 153109548, upload-time = "2026-03-24T19:19:19.523Z" },
@@ -3112,7 +3112,7 @@ name = "nvidia-nvshmem-cu13"
 version = "3.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-cccl", marker = "python_full_version >= '3.11'" },
+    { name = "nvidia-cuda-cccl", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/6b/4c642d2cce57c8bd32043b4a608b6acc8cd0579c2f53af9a7ef9e1e1ccca/nvidia_nvshmem_cu13-3.6.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94aa0149490be658cf95945ce9f16ba90a90edbd6a564366f996ead7496f2f22", size = 71726240, upload-time = "2026-03-24T19:19:29.816Z" },
@@ -3317,7 +3317,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
This PR defines a policy for which versions of Python and Python packages are supported, and adds a make target to apply it automatically.

(I wouldn't be doing this if not for Claude Code.)
