### PR TITLE
Skip slow tests in PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,13 +97,13 @@ jobs:
             {
               "id": "latest",
               "runs-on": "ubuntu-latest",
-              "args": "tests",
+              "argv": "tests",
               "ARGS": "--disable-problematic-sharding"
             },
             {
               "id": "single-cpu",
               "runs-on": "ubuntu-latest",
-              "args": "tests COVERAGE_SUFFIX=-single-cpu",
+              "argv": "tests COVERAGE_SUFFIX=-single-cpu",
               "ARGS": "--num-cpu-devices=1"
             }
           ]'
@@ -170,7 +170,7 @@ jobs:
 
       - name: Run unit tests
         timeout-minutes: 120
-        run: make ${{ matrix.args }} ARGS='${{ matrix.ARGS }}${{ github.event_name == 'pull_request' && ' -m "not slow"' || '' }}'
+        run: make ${{ matrix.argv }} ARGS='${{ matrix.ARGS }}${{ github.event_name == 'pull_request' && ' -m "not slow"' || '' }}'
 
       - name: Save coverage information
         uses: actions/upload-artifact@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,6 +131,9 @@ jobs:
     needs: setup-matrix
     runs-on: ${{ matrix.runs-on }}
 
+    env:
+      RPY2_CFFI_MODE: ${{ github.event_name == 'pull_request' && 'ABI' || '' }}
+
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
@@ -146,16 +149,19 @@ jobs:
           cache-suffix: -${{ matrix.id }}
 
       - name: Install R
+        if: github.event_name != 'pull_request'
         uses: r-lib/actions/setup-r@v2
         with:
           r-version: "renv"
 
       - name: Install R dependencies
+        if: github.event_name != 'pull_request'
         uses: r-lib/actions/setup-renv@v2
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure R PATHS for rpy2 (Linux only)
+        if: github.event_name != 'pull_request'
         run: |
           echo "R_HOME=$(R RHOME)" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$(R RHOME)/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -263,7 +263,7 @@ jobs:
           if-no-files-found: error
 
       - name: Check coverage threshold
-        run: make covcheck
+        run: make covcheck ${{ github.event_name == 'pull_request' && 'ARGS=--fail-under=90' || '' }}
 
   deploy:
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,12 +97,14 @@ jobs:
             {
               "id": "latest",
               "runs-on": "ubuntu-latest",
-              "args": "tests ARGS=--disable-problematic-sharding"
+              "args": "tests",
+              "ARGS": "--disable-problematic-sharding"
             },
             {
               "id": "single-cpu",
               "runs-on": "ubuntu-latest",
-              "args": "tests ARGS=--num-cpu-devices=1 COVERAGE_SUFFIX=-single-cpu"
+              "args": "tests COVERAGE_SUFFIX=-single-cpu",
+              "ARGS": "--num-cpu-devices=1"
             }
           ]'
           BENCHMARKS_BASE_MATRIX='[
@@ -162,7 +164,7 @@ jobs:
 
       - name: Run unit tests
         timeout-minutes: 120
-        run: make ${{ matrix.args }}
+        run: make ${{ matrix.args }} ARGS='${{ matrix.ARGS }}${{ github.event_name == 'pull_request' && ' -m "not slow"' || '' }}'
 
       - name: Save coverage information
         uses: actions/upload-artifact@v7
@@ -226,6 +228,11 @@ jobs:
         with:
           pattern: .coverage*
           merge-multiple: true
+
+      - name: Exclude slow-only code from coverage
+        # slow tests are skipped on PRs, don't count them for coverage
+        if: github.event_name == 'pull_request'
+        run: 'sed -i ''/^\[tool.coverage.report\]$/a exclude_also = ["# pragma: slow"]'' pyproject.toml'
 
       - name: List files
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Exclude slow-only code from coverage
         # slow tests are skipped on PRs, don't count them for coverage
         if: github.event_name == 'pull_request'
-        run: 'sed -i ''/^\[tool.coverage.report\]$/a exclude_also = ["# pragma: slow"]'' pyproject.toml'
+        run: 'sed -i ''/^\[tool.coverage.report\]$/a exclude_also = ["# pragma: slow"]\nomit = ["src/bartz/debug/_traceconv.py"]'' pyproject.toml'
 
       - name: List files
         run: |

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ covcheck:
 	$(UV_RUN) coverage combine --keep
 	$(UV_RUN) coverage report --include='tests/**/test_*.py'
 	$(UV_RUN) coverage report --include='src/*'
-	$(UV_RUN) coverage report --include='tests/**/test_*.py' --fail-under=99 --format=total
+	$(UV_RUN) coverage report --include='tests/**/test_*.py' --fail-under=99 --format=total $(ARGS)
 	$(UV_RUN) coverage report --include='src/*' --fail-under=90 --format=total
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ addopts = [
     "--verbose",
     "--import-mode=importlib",
 ]
+markers = [
+    "slow: marks tests as slow, skipped on PR CI",
+]
 filterwarnings = [
     "ignore:unclosed database:ResourceWarning",
 ]

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -152,6 +152,7 @@ class CachedBart:
     bart: mc_gbart
 
 
+@pytest.mark.slow
 class TestWithCachedBart:
     """Group of slow tests that check the same BART run, for efficiency."""
 
@@ -1354,6 +1355,7 @@ class TestVarprobParam:
                 mc_gbart(**kw)
 
 
+@pytest.mark.slow
 def test_equiv_sharding(kw: dict, subtests: SubTests) -> None:
     """Check that the result is the same with/without sharding."""
     if get_disable_problematic_sharding():  # pragma: no cover

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -62,7 +62,6 @@ from bartz.mcmcloop import compute_varcount, evaluate_trace
 from bartz.mcmcstep import State
 from bartz.mcmcstep._state import chain_vmap_axes
 from tests.conftest import get_disable_problematic_sharding
-from tests.rbartpackages import BART3
 from tests.test_interface import BartKW, gen_X, gen_y, make_kw
 from tests.test_mcmcstep import check_sharding, get_normal_spec, normalize_spec
 from tests.util import (
@@ -73,6 +72,13 @@ from tests.util import (
     periodic_sigint,
     rhat,
 )
+
+try:
+    from tests.rbartpackages import BART3
+except ValueError as exc:
+    # on PR ci, R is not installed because the tests using it are skipped
+    if 'r_home' not in str(exc):
+        raise
 
 
 def bart_kw_to_mc_gbart(bkw: BartKW) -> dict[str, Any]:

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -138,7 +138,14 @@ def make_gbart_kw(key: Key[Array, ''], variant: int) -> dict[str, Any]:
 N_VARIANTS = 3
 
 
-@pytest.fixture(params=list(range(1, N_VARIANTS + 1)), scope='module')
+@pytest.fixture(
+    params=[
+        1,
+        pytest.param(2, marks=pytest.mark.slow),
+        pytest.param(3, marks=pytest.mark.slow),
+    ],
+    scope='module',
+)
 def variant(request: pytest.FixtureRequest) -> int:
     """Return a parametrized indicator to select different BART configurations."""
     return request.param

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -153,7 +153,7 @@ class CachedBart:
 
 
 @pytest.mark.slow
-class TestWithCachedBart:
+class TestWithCachedBart:  # pragma: slow
     """Group of slow tests that check the same BART run, for efficiency."""
 
     @pytest.fixture(scope='class')
@@ -1356,7 +1356,7 @@ class TestVarprobParam:
 
 
 @pytest.mark.slow
-def test_equiv_sharding(kw: dict, subtests: SubTests) -> None:
+def test_equiv_sharding(kw: dict, subtests: SubTests) -> None:  # pragma: slow
     """Check that the result is the same with/without sharding."""
     if get_disable_problematic_sharding():  # pragma: no cover
         pytest.skip('Sharding disabled by --disable-problematic-sharding')

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -415,6 +415,7 @@ class CachedBart:
     bart: Bart
 
 
+@pytest.mark.slow
 class TestWithCachedBart:
     """Group of slow tests that check the same BART run, for efficiency."""
 
@@ -1554,6 +1555,7 @@ def test_debug_checks(keys: split, bkw: BartKW) -> None:
 
 # this entire function is marked not to be covered due to the current desperate
 # hacks in tests.yml, there's its twin in test_BART.py doing some work
+@pytest.mark.slow
 def test_equiv_sharding(bkw: BartKW, subtests: SubTests) -> None:  # pragma: no cover
     """Check that the result is the same with/without sharding."""
     if get_disable_problematic_sharding():  # pragma: no cover

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -216,7 +216,7 @@ def make_kw(key: Key[Array, ''], variant: int) -> BartKW:
             )
 
         # binary regression with binary X and high p
-        case 2:
+        case 2:  # pragma: slow
             X = gen_X(keys.pop(), high_p, n, 'binary')
             bkw = BartKW(
                 kw=dict(
@@ -244,7 +244,7 @@ def make_kw(key: Key[Array, ''], variant: int) -> BartKW:
             )
 
         # continuous regression with error weights and sparsity with fixed theta
-        case 3:
+        case 3:  # pragma: slow
             X = gen_X(keys.pop(), p, n, 'continuous')
             w = gen_w(keys.pop(), X.shape[1])
             bkw = BartKW(
@@ -307,7 +307,7 @@ def make_kw(key: Key[Array, ''], variant: int) -> BartKW:
             )
 
         # multivariate binary regression with binary X and high p
-        case 5:
+        case 5:  # pragma: slow
             X = gen_X(keys.pop(), high_p, n, 'binary')
             bkw = BartKW(
                 kw=dict(
@@ -334,7 +334,7 @@ def make_kw(key: Key[Array, ''], variant: int) -> BartKW:
 
         # multivariate mixed binary-continuous regression with sparsity with
         # fixed theta
-        case 6:  # pragma: no branch
+        case 6:  # pragma: no branch  # pragma: slow
             X = gen_X(keys.pop(), p, n, 'continuous')
             outcome_type = ['continuous', 'binary', 'binary']
             bkw = BartKW(

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -416,7 +416,7 @@ class CachedBart:
 
 
 @pytest.mark.slow
-class TestWithCachedBart:
+class TestWithCachedBart:  # pragma: slow
     """Group of slow tests that check the same BART run, for efficiency."""
 
     @pytest.fixture(scope='class')
@@ -1556,7 +1556,9 @@ def test_debug_checks(keys: split, bkw: BartKW) -> None:
 # this entire function is marked not to be covered due to the current desperate
 # hacks in tests.yml, there's its twin in test_BART.py doing some work
 @pytest.mark.slow
-def test_equiv_sharding(bkw: BartKW, subtests: SubTests) -> None:  # pragma: no cover
+def test_equiv_sharding(  # pragma: no cover  # pragma: slow
+    bkw: BartKW, subtests: SubTests
+) -> None:
     """Check that the result is the same with/without sharding."""
     if get_disable_problematic_sharding():  # pragma: no cover
         pytest.skip('Sharding disabled by --disable-problematic-sharding')

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -378,7 +378,14 @@ def make_kw(key: Key[Array, ''], variant: int) -> BartKW:
 
 # test only the multivariate variants, because the other ones are tested in
 # test_BART.py
-@pytest.fixture(params=(4, 5, 6), scope='module')
+@pytest.fixture(
+    params=(
+        4,
+        pytest.param(5, marks=pytest.mark.slow),
+        pytest.param(6, marks=pytest.mark.slow),
+    ),
+    scope='module',
+)
 def variant(request: FixtureRequest) -> int:
     """Return a parametrized indicator to select different BART configurations."""
     return request.param

--- a/tests/test_mcmcstep.py
+++ b/tests/test_mcmcstep.py
@@ -647,7 +647,7 @@ class TestMultichain:
     @pytest.mark.slow
     @pytest.mark.parametrize('num_chains', [None, 0, 1, -1, 4, -4])
     @pytest.mark.parametrize('shard_data', [False, True])
-    def test_basic(
+    def test_basic(  # pragma: slow
         self,
         init_kwargs: dict,
         num_chains: int | None,

--- a/tests/test_mcmcstep.py
+++ b/tests/test_mcmcstep.py
@@ -644,6 +644,7 @@ class TestMultichain:
 
         return kw
 
+    @pytest.mark.slow
     @pytest.mark.parametrize('num_chains', [None, 0, 1, -1, 4, -4])
     @pytest.mark.parametrize('shard_data', [False, True])
     def test_basic(


### PR DESCRIPTION
Tests are too slow on CI. This PR makes cis within PRs skip a set of tests, manually marked as slow.
