### PR TITLE
Make version-dependent xfail specific

### DIFF
--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -30,7 +30,6 @@ This is the main suite of tests.
 from dataclasses import dataclass, replace
 from functools import partial
 from inspect import signature
-from sys import version_info
 from typing import Any, Literal
 
 import jax
@@ -76,7 +75,6 @@ from tests.test_mcmcstep import check_sharding, get_normal_spec, normalize_spec
 from tests.util import (
     assert_close_matrices,
     assert_different_matrices,
-    get_old_python_tuple,
     multivariate_rhat,
     periodic_sigint,
     rhat,
@@ -1358,8 +1356,9 @@ def check_chain_sharding(x: Array | None, mesh: Mesh) -> None:
 
 def test_sharding(kw: dict, variant: int) -> None:
     """Check that chains live on their own devices throughout the interface."""
-    if version_info[:2] == get_old_python_tuple() and variant in (2, 5):
-        pytest.xfail('Actual sharding bug in bartz with old jax, no time to fix.')
+    # WORKAROUND(jax<0.7): sharding bug, no time to fix
+    if jax.__version_info__ < (0, 7, 0) and variant in (2, 5):
+        pytest.xfail('Sharding bug in bartz with jax<0.7.')
     bart = mc_gbart(**kw)
 
     # check the mesh is set up iff we expect sharding

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -34,7 +34,6 @@ from functools import partial
 from gc import collect
 from inspect import signature
 from io import StringIO
-from sys import version_info
 from typing import Any, Literal, NamedTuple
 from weakref import ReferenceType, ref
 
@@ -83,7 +82,6 @@ from tests.test_mcmcstep import check_sharding, get_normal_spec, normalize_spec
 from tests.util import (
     assert_close_matrices,
     assert_different_matrices,
-    get_old_python_tuple,
     multivariate_rhat,
     periodic_sigint,
     rhat,
@@ -1461,8 +1459,9 @@ def get_expect_sharded(kw: dict) -> bool:
 
 def test_sharding(bkw: BartKW, variant: int, keys: split) -> None:
     """Check that chains and data shards live on their own devices throughout the interface."""
-    if version_info[:2] == get_old_python_tuple() and variant in (2, 5):
-        pytest.xfail('Actual sharding bug in bartz with old jax, no time to fix.')
+    # WORKAROUND(jax<0.7): sharding bug, no time to fix
+    if jax.__version_info__ < (0, 7, 0) and variant in (2, 5):
+        pytest.xfail('Sharding bug in bartz with jax<0.7.')
     kw = bkw.kw
     bart = Bart(**kw)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -29,14 +29,12 @@ from contextlib import contextmanager
 from dataclasses import replace
 from operator import ge, le
 from os import getpid, kill
-from pathlib import Path
 from signal import SIGINT
 from threading import Event, Thread
 from time import monotonic
 from typing import Any
 
 import numpy as np
-import tomli
 from jax import numpy as jnp
 from jax import vmap
 from jax.scipy.linalg import solve_triangular
@@ -195,19 +193,6 @@ def assert_different_matrices(*args: ArrayLike, **kwargs: Any) -> None:
     default_kwargs: dict = dict(rtol=np.inf, atol=np.inf)
     default_kwargs.update(kwargs)
     assert_close_matrices(*args, negate=True, **default_kwargs)
-
-
-def get_old_python_str() -> str:
-    """Read the oldest supported Python from pyproject.toml."""
-    with Path('pyproject.toml').open('rb') as file:
-        return tomli.load(file)['project']['requires-python'].removeprefix('>=')
-
-
-def get_old_python_tuple() -> tuple[int, int]:
-    """Read the oldest supported Python from pyproject.toml as a tuple."""
-    ver_str = get_old_python_str()
-    major, minor = ver_str.split('.')
-    return int(major), int(minor)
 
 
 def multivariate_rhat(chains: Real[Array, 'chain sample dim']) -> Float[Array, '']:


### PR DESCRIPTION
This PR makes an important xfail that depends on the jax version specifically trigger on the problematic jax versions instead of relying on the heuristic of "we are running the old tests suite".
