### PR TITLE
Misc test chores

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,7 +27,6 @@ To check the code you write:
 - `make lint`
 - `make setup`
     - this is needed before running any tests
-    - pre-commit may complain during this if you are in a worktree, ignore that
 - run the unit tests relevant to your code changes with `uv run pytest ...`
     - not all tests right away because the full test suite takes a long time to run
     - when running multiple tests, the output may be long; pipe the output to a scratch file to be read afterwards

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,8 @@ banned-from = ["jax.random", "jax.lax", "jax.numpy", "jax.tree"]
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "jax.lax.reciprocal".msg = "Use jnp.reciprocal"
 "jax.random.PRNGKey".msg = "User jax.random.key"
+"numpy.testing.assert_allclose".msg = "Use tests.util.assert_allclose (zero default tolerances)."
+"numpy.testing.assert_array_equal".msg = "Use tests.util.assert_array_equal (strict=True default)."
 
 [tool.pydoclint]
 arg-type-hints-in-signature = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,12 +24,15 @@
 
 """Pytest configuration."""
 
+import sys
 from contextlib import nullcontext
+from pathlib import Path
 from re import fullmatch
 
 import jax
 import numpy as np
 import pytest
+import tomli
 from jax import config, random
 
 from bartz.jaxext import get_default_device, split
@@ -42,6 +45,16 @@ def get_disable_problematic_sharding() -> bool:
     return DISABLE_PROBLEMATIC_SHARDING
 
 
+def get_old_python_version() -> tuple[int, int]:
+    """Return the minimum Python version required by pyproject.toml as (major, minor)."""
+    pyproject = Path(__file__).parent.parent / 'pyproject.toml'
+    with pyproject.open('rb') as f:
+        data = tomli.load(f)
+    spec = data['project']['requires-python'].strip()
+    match = fullmatch(r'>=\s*(\d+)\.(\d+)', spec)
+    return (int(match.group(1)), int(match.group(2)))
+
+
 INVASIVE_DEBUG_CHECKS = False
 if INVASIVE_DEBUG_CHECKS:
     # they make the tests 10% slower, disable buffer donation, and yield some
@@ -50,16 +63,17 @@ if INVASIVE_DEBUG_CHECKS:
     config.update('jax_debug_nans', True)
     config.update('jax_debug_infs', True)
 config.update('jax_legacy_prng_key', 'error')
-if jax.__version_info__ >= (0, 9, 0):
-    config.update('jax_check_static_indices', True)
+if jax.__version_info__ >= (0, 8, 0):
     config.update('jax_explicit_x64_dtypes', 'error')
+if jax.__version_info__ >= (0, 8, 2):
+    config.update('jax_check_static_indices', True)
 
 # enable logging arrays destroyed by the gc
 config.update('jax_array_garbage_collection_guard', 'log')
 
 # enable compilation cache
-if jax.__version_info__ >= (0, 9, 0):
-    # enable only on latest jax because `make tests-old` fails if there is a
+if sys.version_info[:2] > get_old_python_version():
+    # enable only on latest config because `make tests-old` fails if there is a
     # cache created with a newer jax version
     config.update('jax_compilation_cache_dir', 'config/jax_cache')
     config.update('jax_persistent_cache_min_entry_size_bytes', -1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,8 +63,10 @@ if INVASIVE_DEBUG_CHECKS:
     config.update('jax_debug_nans', True)
     config.update('jax_debug_infs', True)
 config.update('jax_legacy_prng_key', 'error')
+# WORKAROUND(jax<0.8.0): jax_explicit_x64_dtypes config option added in 0.8.0
 if jax.__version_info__ >= (0, 8, 0):
     config.update('jax_explicit_x64_dtypes', 'error')
+# WORKAROUND(jax<0.8.2): jax_check_static_indices config option added in 0.8.2
 if jax.__version_info__ >= (0, 8, 2):
     config.update('jax_check_static_indices', True)
 

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -203,9 +203,6 @@ def make_gbart_kw(key: Key[Array, ''], variant: int) -> dict[str, Any]:
     return bart_kw_to_mc_gbart(make_kw(key, variant))
 
 
-N_VARIANTS = 3
-
-
 @pytest.fixture(
     params=[
         1,
@@ -243,8 +240,8 @@ class TestWithCachedBart:  # pragma: slow
         # create a random seed that depends only on the variant, since this
         # fixture is shared between multiple tests
         key = random.key(0x139CD0C0)
-        keys = random.split(key, N_VARIANTS)
-        key = keys[variant - 1]
+        keys = random.split(key, 10)  # 10 is just some high number
+        key = keys[variant]
         kw = make_gbart_kw(key, variant)
 
         # modify configs to make them appropriate for convergence checks and R

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -428,16 +428,18 @@ class TestWithCachedBart:  # pragma: slow
         else:  # continuous regression
             with subtests.test('yhat_train_mean'):
                 assert_close_matrices(
-                    bart.yhat_train_mean,
-                    rbart.yhat_train_mean.astype(numpy.float32),
-                    rtol=0.8,
+                    bart.yhat_train_mean - rbart.yhat_train_mean.astype(numpy.float32),
+                    jnp.concatenate([bart.yhat_train, rbart.yhat_train]).std(axis=0),
+                    tozero=True,
+                    rtol=0.3,
                 )
 
             with subtests.test('yhat_test_mean'):
                 assert_close_matrices(
-                    bart.yhat_test_mean,
-                    rbart.yhat_test_mean.astype(numpy.float32),
-                    rtol=0.9,
+                    bart.yhat_test_mean - rbart.yhat_test_mean.astype(numpy.float32),
+                    jnp.concatenate([bart.yhat_test, rbart.yhat_test]).std(axis=0),
+                    tozero=True,
+                    rtol=0.3,
                 )
 
             with subtests.test('sigma'):

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -77,9 +77,7 @@ from tests.util import (
     assert_array_equal,
     assert_close_matrices,
     assert_different_matrices,
-    multivariate_rhat,
     periodic_sigint,
-    rhat,
     rhat_rank,
 )
 
@@ -292,33 +290,33 @@ class TestWithCachedBart:  # pragma: slow
 
         with subtests.test('yhat_train'):
             yhat_train = bart.yhat_train.reshape(nchains, nsamples, n)
-            rhat_yhat_train = multivariate_rhat(yhat_train)
-            assert rhat_yhat_train < 6
+            rhat_yhat_train = rhat_rank(yhat_train, split=True)
+            assert_array_less(rhat_yhat_train, 6)
 
         if get_with_default(kw, 'type') == 'pbart':  # binary regression
             with subtests.test('prob_train'):
                 prob_train = bart.prob_train.reshape(nchains, nsamples, n)
-                rhat_prob_train = multivariate_rhat(prob_train)
-                assert rhat_prob_train < 1.2
+                rhat_prob_train = rhat_rank(prob_train, split=True)
+                assert_array_less(rhat_prob_train, 1.2)
 
         else:  # continuous regression
             with subtests.test('sigma'):
                 sigma = bart.sigma[nsamples:, :].T
-                rhat_sigma = rhat(sigma)
+                rhat_sigma = rhat_rank(sigma, split=True)
                 assert rhat_sigma < 1.2
 
         if p < n:
             with subtests.test('varcount'):
                 varcount = bart.varcount.reshape(nchains, nsamples, p)
-                rhat_varcount = multivariate_rhat(varcount)
-                assert rhat_varcount < 7
+                rhat_varcount = rhat_rank(varcount, split=True)
+                assert_array_less(rhat_varcount, 7)
 
             if get_with_default(kw, 'sparse'):  # pragma: no branch
                 with subtests.test('varprob'):
                     varprob = bart.varprob.reshape(nchains, nsamples, p)
-                    rhat_varprob = multivariate_rhat(varprob[:, :, 1:])
+                    rhat_varprob = rhat_rank(varprob[:, :, 1:], split=True)
                     # drop one component because varprob sums to 1
-                    assert rhat_varprob < 7
+                    assert_array_less(rhat_varprob, 7)
 
     def kw_bartz_to_BART3(self, key: Key[Array, ''], kw: dict, bart: mc_gbart) -> dict:
         """Convert bartz keyword arguments to R BART3 keyword arguments."""
@@ -408,21 +406,27 @@ class TestWithCachedBart:  # pragma: slow
             # the documentation says
 
         with subtests.test('yhat_train'):
-            rhat_yhat_train = multivariate_rhat([bart.yhat_train, rbart.yhat_train])
-            assert rhat_yhat_train < 3.5
+            rhat_yhat_train = rhat_rank(
+                [bart.yhat_train, rbart.yhat_train], split=False
+            )
+            assert_array_less(rhat_yhat_train, 3.5)
 
         with subtests.test('yhat_test'):
-            rhat_yhat_test = multivariate_rhat([bart.yhat_test, rbart.yhat_test])
-            assert rhat_yhat_test < 3.5
+            rhat_yhat_test = rhat_rank([bart.yhat_test, rbart.yhat_test], split=False)
+            assert_array_less(rhat_yhat_test, 3.5)
 
         if get_with_default(kw, 'type') == 'pbart':  # binary regression
             with subtests.test('prob_train'):
-                rhat_prob_train = multivariate_rhat([bart.prob_train, rbart.prob_train])
-                assert rhat_prob_train < 1.2
+                rhat_prob_train = rhat_rank(
+                    [bart.prob_train, rbart.prob_train], split=False
+                )
+                assert_array_less(rhat_prob_train, 1.2)
 
             with subtests.test('prob_test'):
-                rhat_prob_test = multivariate_rhat([bart.prob_test, rbart.prob_test])
-                assert rhat_prob_test < 1.2
+                rhat_prob_test = rhat_rank(
+                    [bart.prob_test, rbart.prob_test], split=False
+                )
+                assert_array_less(rhat_prob_test, 1.2)
 
         else:  # continuous regression
             with subtests.test('yhat_train_mean'):
@@ -440,8 +444,9 @@ class TestWithCachedBart:  # pragma: slow
                 )
 
             with subtests.test('sigma'):
-                rhat_sigma = rhat(
-                    [bart.sigma_[-bart.ndpost :], rbart.sigma_[-rbart.ndpost :]]
+                rhat_sigma = rhat_rank(
+                    [bart.sigma_[-bart.ndpost :], rbart.sigma_[-rbart.ndpost :]],
+                    split=False,
                 )
                 assert rhat_sigma < 1.3
 
@@ -452,7 +457,7 @@ class TestWithCachedBart:  # pragma: slow
             # check number of tree nodes in forest
             bart_count = bart.varcount.sum(axis=1)
             rbart_count = rbart.varcount.sum(axis=1)
-            rhat_count = rhat([bart_count, rbart_count])
+            rhat_count = rhat_rank([bart_count, rbart_count], split=False)
             assert rhat_count < 30  # genuinely bad, see below
             assert_allclose(bart_count.mean(), rbart_count.mean(), rtol=0.2)
 
@@ -461,11 +466,11 @@ class TestWithCachedBart:  # pragma: slow
             # stuff about predictors right
 
             with subtests.test('varcount'):
-                rhat_varcount = multivariate_rhat([bart.varcount, rbart.varcount])
+                rhat_varcount = rhat_rank([bart.varcount, rbart.varcount], split=False)
                 # there is a visible discrepancy on the number of nodes, with bartz
                 # having deeper trees, this 6 is not just "not good to sampling
                 # accuracy but close in practice."
-                assert rhat_varcount < 7
+                assert_array_less(rhat_varcount, 7)
 
             with subtests.test('varcount_mean'):
                 assert_close_matrices(
@@ -477,13 +482,14 @@ class TestWithCachedBart:  # pragma: slow
 
             if kw.get('sparse', False):  # pragma: no branch
                 with subtests.test('varprob'):
-                    rhat_varprob = multivariate_rhat(
+                    rhat_varprob = rhat_rank(
                         clipped_logit(
                             jnp.stack([bart.varprob, rbart.varprob])[:, :, 1:], 1e-5
-                        )
+                        ),
+                        split=False,
                     )
                     # drop one component because varprob sums to 1
-                    assert rhat_varprob < 4
+                    assert_array_less(rhat_varprob, 4)
 
                 with subtests.test('varprob_mean'):
                     assert_close_matrices(
@@ -1017,7 +1023,7 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
     with subtests.test('number of stub trees'):
         nstub_mcmc = count_stub_trees(bart._main_trace.split_tree)
         nstub_prior = count_stub_trees(prior_trace.split_tree)
-        rhat_nstub = rhat([nstub_mcmc, nstub_prior])
+        rhat_nstub = rhat_rank([nstub_mcmc, nstub_prior], split=False)
         assert rhat_nstub < 1.01
 
     if (p, nsplits) != (1, 1):
@@ -1026,7 +1032,7 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
         with subtests.test('number of simple trees'):
             nsimple_mcmc = count_simple_trees(bart._main_trace.split_tree)
             nsimple_prior = count_simple_trees(prior_trace.split_tree)
-            rhat_nsimple = rhat([nsimple_mcmc, nsimple_prior])
+            rhat_nsimple = rhat_rank([nsimple_mcmc, nsimple_prior], split=False)
             assert rhat_nsimple < 1.01
 
         varcount_prior = compute_varcount(
@@ -1034,43 +1040,45 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
         )
 
         with subtests.test('varcount'):
-            rhat_varcount = multivariate_rhat([bart.varcount, varcount_prior])
+            rhat_varcount = rhat_rank([bart.varcount, varcount_prior], split=False)
             if p == 10:
                 # varcount is p-dimensional
-                assert rhat_varcount < 1.4
+                assert_array_less(rhat_varcount, 1.4)
             else:
-                assert rhat_varcount < 1.2
+                assert_array_less(rhat_varcount, 1.2)
 
         with subtests.test('number of nodes'):
             sum_varcount_mcmc = bart.varcount.sum(axis=1)
             sum_varcount_prior = varcount_prior.sum(axis=1)
-            rhat_sum_varcount = rhat([sum_varcount_mcmc, sum_varcount_prior])
+            rhat_sum_varcount = rhat_rank(
+                [sum_varcount_mcmc, sum_varcount_prior], split=False
+            )
             assert rhat_sum_varcount < 1.05
 
         with subtests.test('imbalance index'):
             imb_mcmc = avg_imbalance_index(bart._main_trace.split_tree)
             imb_prior = avg_imbalance_index(prior_trace.split_tree)
-            rhat_imb = rhat([imb_mcmc, imb_prior])
+            rhat_imb = rhat_rank([imb_mcmc, imb_prior], split=False)
             assert rhat_imb < 1.02
 
         with subtests.test('average max tree depth'):
             maxd_mcmc = avg_max_tree_depth(bart._main_trace.split_tree)
             maxd_prior = avg_max_tree_depth(prior_trace.split_tree)
-            rhat_maxd = rhat([maxd_mcmc, maxd_prior])
+            rhat_maxd = rhat_rank([maxd_mcmc, maxd_prior], split=False)
             assert rhat_maxd < 1.02
 
         with subtests.test('max tree depth distribution'):
             dd_mcmc = bart.depth_distr()
             dd_prior = forest_depth_distr(prior_trace.split_tree)
-            rhat_dd = multivariate_rhat([dd_mcmc.squeeze(0), dd_prior])
-            assert rhat_dd < 1.05
+            rhat_dd = rhat_rank([dd_mcmc.squeeze(0), dd_prior], split=False)
+            assert_array_less(rhat_dd, 1.05)
 
     with subtests.test('y_test'):
         X = random.randint(keys.pop(), (p, 30), 0, nsplits + 1)
         yhat_mcmc = bart._bart._predict(X)
         yhat_prior = evaluate_trace(X, prior_trace)
-        rhat_yhat = multivariate_rhat([yhat_mcmc, yhat_prior])
-        assert rhat_yhat < 1.1
+        rhat_yhat = rhat_rank([yhat_mcmc, yhat_prior], split=False)
+        assert_array_less(rhat_yhat, 1.1)
 
 
 def run_bart_like_prior(
@@ -1177,17 +1185,6 @@ def avg_max_tree_depth(
     """Measure average maximum tree depth in the forest."""
     depth = vmap(tree_actual_depth)(split_tree)
     return depth.mean(-1)
-
-
-def test_rhat(keys: split) -> None:
-    """Test the multivariate R-hat implementation."""
-    chains, divergent_chains = random.normal(keys.pop(), (2, 2, 1000, 10))
-    mean_offset = jnp.arange(len(chains))
-    divergent_chains += mean_offset[:, None, None]
-    rhat = multivariate_rhat(chains)
-    rhat_divergent = multivariate_rhat(divergent_chains)
-    assert rhat < 1.02
-    assert rhat_divergent > 5
 
 
 @pytest.mark.parametrize('split', [True, False])

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -77,6 +77,7 @@ from tests.util import (
     assert_array_equal,
     assert_close_matrices,
     assert_different_matrices,
+    clipped_logit,
     periodic_sigint,
     rhat_rank,
 )
@@ -296,8 +297,8 @@ class TestWithCachedBart:  # pragma: slow
         if get_with_default(kw, 'type') == 'pbart':  # binary regression
             with subtests.test('prob_train'):
                 prob_train = bart.prob_train.reshape(nchains, nsamples, n)
-                rhat_prob_train = rhat_rank(prob_train, split=True)
-                assert_array_less(rhat_prob_train, 1.01)
+                rhat_prob_train = rhat_rank(clipped_logit(prob_train, 1e-5), split=True)
+                assert_array_less(rhat_prob_train, 1.005)
 
         else:  # continuous regression
             with subtests.test('sigma'):
@@ -418,15 +419,17 @@ class TestWithCachedBart:  # pragma: slow
         if get_with_default(kw, 'type') == 'pbart':  # binary regression
             with subtests.test('prob_train'):
                 rhat_prob_train = rhat_rank(
-                    [bart.prob_train, rbart.prob_train], split=False
+                    clipped_logit(jnp.stack([bart.prob_train, rbart.prob_train]), 1e-5),
+                    split=False,
                 )
-                assert_array_less(rhat_prob_train, 1.01)
+                assert_array_less(rhat_prob_train, 1.005)
 
             with subtests.test('prob_test'):
                 rhat_prob_test = rhat_rank(
-                    [bart.prob_test, rbart.prob_test], split=False
+                    clipped_logit(jnp.stack([bart.prob_test, rbart.prob_test]), 1e-5),
+                    split=False,
                 )
-                assert_array_less(rhat_prob_test, 1.01)
+                assert_array_less(rhat_prob_test, 1.005)
 
         else:  # continuous regression
             with subtests.test('yhat_train_mean'):
@@ -534,11 +537,6 @@ class TestWithCachedBart:  # pragma: slow
         assert_different(bart._mcmc_state, rtol=0.01)
         assert_different(bart._main_trace, rtol=0.03)
         assert_different(bart._burnin_trace, rtol=0.03)
-
-
-def clipped_logit(x: Array, eps: float) -> Array:
-    """Compute the logit of x, clipping x to [eps, 1-eps] to avoid infinities."""
-    return logit(jnp.clip(x, eps, 1 - eps))
 
 
 def test_sequential_guarantee(kw: dict, subtests: SubTests) -> None:

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -841,58 +841,12 @@ def set_num_datapoints(kw: dict, n: int) -> dict:
     return kw
 
 
-def test_no_datapoints(kw: dict[str, Any]) -> None:
-    """Check automatic data scaling with 0 datapoints."""
-    # remove all datapoints
-    kw = set_num_datapoints(kw, 0)
+@pytest.mark.parametrize('num_datapoints', [0, 1])
+def test_zero_or_one_datapoint(kw: dict[str, Any], num_datapoints: int) -> None:
+    """Check automatic data scaling with 0 or 1 datapoints."""
+    kw = set_num_datapoints(kw, num_datapoints)
 
-    # set the split grid manually because automatic setting relies on datapoints
-    p, _ = kw['x_train'].shape
-    nsplits = 10
-    xinfo = jnp.broadcast_to(jnp.arange(nsplits, dtype=jnp.float32), (p, nsplits))
-    kw.update(xinfo=xinfo)
-
-    # disable data sharding
-    kw.setdefault('bart_kwargs', {}).update(num_data_devices=None)
-
-    # enable saving the likelihood ratio to check it's always 1
-    kw.setdefault('bart_kwargs', {}).setdefault('init_kw', {}).update(
-        save_ratios=True, min_points_per_decision_node=None, min_points_per_leaf=None
-    )
-
-    # run bart
-    bart = mc_gbart(**kw)
-
-    # check there are indeed 0 datapoints in the output
-    ndpost = get_with_default(kw, 'ndpost')
-    assert bart.yhat_train.shape == (ndpost, 0)
-
-    # check default values that may be set in a special way if there are 0 datapoints
-    assert bart.offset == 0
-    if get_with_default(kw, 'type') == 'pbart':
-        tau_num = 3
-        assert bart.sigest is None
-    else:
-        tau_num = 1
-        assert bart.sigest == 1
-    assert_allclose(
-        bart._mcmc_state.forest.leaf_prior_cov_inv,
-        (2**2 * get_with_default(kw, 'ntree')) / tau_num**2,
-        rtol=1e-6,
-    )
-
-    # check the likelihood ratio is always 1
-    assert_array_equal(bart._burnin_trace.log_likelihood, 0.0, strict=False)
-    assert_array_equal(bart._main_trace.log_likelihood, 0.0, strict=False)
-
-
-def test_one_datapoint(kw: dict[str, Any]) -> None:
-    """Check automatic data scaling with 1 datapoint."""
-    kw = set_num_datapoints(kw, 1)
-
-    # set the split grid manually because otherwise there would be 0 cutpoints
-    # when usequants=True, and computing varprob produces nans in that case
-    if kw.get('usequants', False):
+    if num_datapoints == 0 or get_with_default(kw, 'usequants'):
         p, _ = kw['x_train'].shape
         nsplits = 10
         xinfo = jnp.broadcast_to(jnp.arange(nsplits, dtype=jnp.float32), (p, nsplits))
@@ -906,7 +860,14 @@ def test_one_datapoint(kw: dict[str, Any]) -> None:
         save_ratios=True, min_points_per_decision_node=None, min_points_per_leaf=None
     )
 
+    # run bart
     bart = mc_gbart(**kw)
+
+    # check there are indeed num_datapoints datapoints in the output
+    ndpost = get_with_default(kw, 'ndpost')
+    assert bart.yhat_train.shape == (ndpost, num_datapoints)
+
+    # check default values that may be set in a special way
     if get_with_default(kw, 'type') == 'pbart':
         tau_num = 3
         assert bart.sigest is None
@@ -914,7 +875,10 @@ def test_one_datapoint(kw: dict[str, Any]) -> None:
     else:
         tau_num = 1
         assert bart.sigest == 1
-        assert bart.offset == kw['y_train'].item()
+        if num_datapoints:
+            assert bart.offset == kw['y_train'].item()
+        else:
+            assert bart.offset == 0
     assert_allclose(
         bart._mcmc_state.forest.leaf_prior_cov_inv,
         (2**2 * get_with_default(kw, 'ntree')) / tau_num**2,

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -43,7 +43,6 @@ from jax.scipy.special import logit, ndtr
 from jax.sharding import Mesh, SingleDeviceSharding
 from jax.tree_util import KeyPath, keystr
 from jaxtyping import Array, Float32, Int32, Key, PyTree, Shaped, UInt
-from numpy.testing import assert_allclose, assert_array_equal
 from pytest_subtests import SubTests
 
 from bartz import Bart
@@ -73,6 +72,8 @@ from tests.conftest import get_disable_problematic_sharding
 from tests.test_interface import BartKW, gen_X, gen_y, make_kw
 from tests.test_mcmcstep import check_sharding, get_normal_spec, normalize_spec
 from tests.util import (
+    assert_allclose,
+    assert_array_equal,
     assert_close_matrices,
     assert_different_matrices,
     multivariate_rhat,
@@ -699,8 +700,8 @@ class TestVarprobAttr:
         with debug_nans(False):
             xinfo = jnp.array([[jnp.nan], [0]])
         bart = mc_gbart(x_train=X, y_train=y, xinfo=xinfo, seed=keys.pop())
-        assert_array_equal(bart._mcmc_state.forest.max_split, [0, 1])
-        assert_array_equal(bart.varprob_mean, [0, 1])
+        assert_array_equal(bart._mcmc_state.forest.max_split, [0, 1], strict=False)
+        assert_array_equal(bart.varprob_mean, [0, 1], strict=False)
         assert jnp.all(bart.varprob_mean == bart.varprob)
 
 
@@ -876,8 +877,8 @@ def test_no_datapoints(kw: dict[str, Any]) -> None:
     )
 
     # check the likelihood ratio is always 1
-    assert_array_equal(bart._burnin_trace.log_likelihood, 0.0)
-    assert_array_equal(bart._main_trace.log_likelihood, 0.0)
+    assert_array_equal(bart._burnin_trace.log_likelihood, 0.0, strict=False)
+    assert_array_equal(bart._main_trace.log_likelihood, 0.0, strict=False)
 
 
 def test_one_datapoint(kw: dict[str, Any]) -> None:
@@ -916,8 +917,8 @@ def test_one_datapoint(kw: dict[str, Any]) -> None:
     )
 
     # check the likelihood ratio is always 1
-    assert_array_equal(bart._burnin_trace.log_likelihood, 0.0)
-    assert_array_equal(bart._main_trace.log_likelihood, 0.0)
+    assert_array_equal(bart._burnin_trace.log_likelihood, 0.0, strict=False)
+    assert_array_equal(bart._main_trace.log_likelihood, 0.0, strict=False)
 
 
 def test_two_datapoints(kw: dict[str, Any]) -> None:
@@ -978,7 +979,7 @@ def test_xinfo() -> None:
 
     xinfo_wo_nan = jnp.where(jnp.isnan(xinfo), jnp.finfo(jnp.float32).max, xinfo)
     assert_array_equal(bart._splits, xinfo_wo_nan)
-    assert_array_equal(bart._mcmc_state.forest.max_split, [2, 3, 0])
+    assert_array_equal(bart._mcmc_state.forest.max_split, [2, 3, 0], strict=False)
 
 
 def test_xinfo_wrong_p() -> None:
@@ -1102,8 +1103,8 @@ def run_bart_like_prior(
     bart = mc_gbart(**kw)
 
     with subtests.test('likelihood ratio = 1'):
-        assert_array_equal(bart._burnin_trace.log_likelihood, 0.0)
-        assert_array_equal(bart._main_trace.log_likelihood, 0.0)
+        assert_array_equal(bart._burnin_trace.log_likelihood, 0.0, strict=False)
+        assert_array_equal(bart._main_trace.log_likelihood, 0.0, strict=False)
 
     return bart
 

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -1190,34 +1190,40 @@ def test_rhat(keys: split) -> None:
     assert rhat_divergent > 5
 
 
-def test_rhat_rank(keys: split) -> None:
-    """Test the rank-normalized split-Rhat port from arviz_stats."""
+@pytest.mark.parametrize('split', [True, False])
+def test_rhat_rank(keys: split, split: bool) -> None:
+    """Test the rank-normalized (split-)Rhat port from arviz_stats."""
     chains, divergent_chains = random.normal(keys.pop(), (2, 2, 1000, 10))
     mean_offset = 10 * jnp.arange(len(chains))
     divergent_chains += mean_offset[:, None, None]
-    rhat = rhat_rank(chains)
-    rhat_divergent = rhat_rank(divergent_chains)
+    rhat = rhat_rank(chains, split=split)
+    rhat_divergent = rhat_rank(divergent_chains, split=split)
     assert rhat.shape == (10,)
     assert rhat_divergent.shape == (10,)
     assert_array_less(rhat, 1.01)
     assert_array_less(1.3, rhat_divergent)
 
 
-def test_rhat_rank_axes(keys: split) -> None:
+@pytest.mark.parametrize('split', [True, False])
+def test_rhat_rank_axes(keys: split, split: bool) -> None:
     """Test ``rhat_rank`` honors ``chain_axis`` and ``draw_axis``."""
     chains = random.normal(keys.pop(), (2, 1000, 5))
-    reference = rhat_rank(chains)
+    reference = rhat_rank(chains, split=split)
     transposed = jnp.moveaxis(chains, (0, 1), (2, 0))
-    relocated = rhat_rank(transposed, chain_axis=2, draw_axis=0)
+    relocated = rhat_rank(transposed, split=split, chain_axis=2, draw_axis=0)
     assert_allclose(relocated, reference, rtol=1e-12)
 
 
 def test_rhat_rank_shape_errors() -> None:
     """Test ``rhat_rank`` rejects undersized chain/draw dimensions."""
     with pytest.raises(ValueError, match='2 chains'):
-        rhat_rank(jnp.zeros((1, 200)))
+        rhat_rank(jnp.zeros((1, 200)), split=True)
     with pytest.raises(ValueError, match='4 draws'):
-        rhat_rank(jnp.zeros((2, 3)))
+        rhat_rank(jnp.zeros((2, 3)), split=True)
+    with pytest.raises(ValueError, match='2 chains'):
+        rhat_rank(jnp.zeros((1, 200)), split=False)
+    with pytest.raises(ValueError, match='2 draws'):
+        rhat_rank(jnp.zeros((2, 1)), split=False)
 
 
 def test_jit(kw: dict[str, Any]) -> None:

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -280,7 +280,7 @@ class TestWithCachedBart:  # pragma: slow
         )
         assert_close_matrices(accum_resid, actual_resid, rtol=1e-4)
 
-    def test_convergence(self, cachedbart: CachedBart) -> None:
+    def test_convergence(self, cachedbart: CachedBart, subtests: SubTests) -> None:
         """Run multiple chains and check convergence with rhat."""
         bart = cachedbart.bart
         nchains, _ = bart._mcmc_state.resid.shape
@@ -288,35 +288,35 @@ class TestWithCachedBart:  # pragma: slow
         kw = cachedbart.kwargs
         p, n = kw['x_train'].shape
 
-        yhat_train = bart.yhat_train.reshape(nchains, nsamples, n)
-        rhat_yhat_train = multivariate_rhat(yhat_train)
-        assert rhat_yhat_train < 6
-        print(f'{rhat_yhat_train.item()=}')
+        with subtests.test('yhat_train'):
+            yhat_train = bart.yhat_train.reshape(nchains, nsamples, n)
+            rhat_yhat_train = multivariate_rhat(yhat_train)
+            assert rhat_yhat_train < 6
 
         if get_with_default(kw, 'type') == 'pbart':  # binary regression
-            prob_train = bart.prob_train.reshape(nchains, nsamples, n)
-            rhat_prob_train = multivariate_rhat(prob_train)
-            assert rhat_prob_train < 1.2
-            print(f'{rhat_prob_train.item()=}')
+            with subtests.test('prob_train'):
+                prob_train = bart.prob_train.reshape(nchains, nsamples, n)
+                rhat_prob_train = multivariate_rhat(prob_train)
+                assert rhat_prob_train < 1.2
 
         else:  # continuous regression
-            sigma = bart.sigma[nsamples:, :].T
-            rhat_sigma = rhat(sigma)
-            assert rhat_sigma < 1.2
-            print(f'{rhat_sigma.item()=}')
+            with subtests.test('sigma'):
+                sigma = bart.sigma[nsamples:, :].T
+                rhat_sigma = rhat(sigma)
+                assert rhat_sigma < 1.2
 
         if p < n:
-            varcount = bart.varcount.reshape(nchains, nsamples, p)
-            rhat_varcount = multivariate_rhat(varcount)
-            assert rhat_varcount < 7
-            print(f'{rhat_varcount.item()=}')
+            with subtests.test('varcount'):
+                varcount = bart.varcount.reshape(nchains, nsamples, p)
+                rhat_varcount = multivariate_rhat(varcount)
+                assert rhat_varcount < 7
 
             if get_with_default(kw, 'sparse'):  # pragma: no branch
-                varprob = bart.varprob.reshape(nchains, nsamples, p)
-                rhat_varprob = multivariate_rhat(varprob[:, :, 1:])
-                # drop one component because varprob sums to 1
-                assert rhat_varprob < 7
-                print(f'{rhat_varprob.item()=}')
+                with subtests.test('varprob'):
+                    varprob = bart.varprob.reshape(nchains, nsamples, p)
+                    rhat_varprob = multivariate_rhat(varprob[:, :, 1:])
+                    # drop one component because varprob sums to 1
+                    assert rhat_varprob < 7
 
     def kw_bartz_to_BART3(self, key: Key[Array, ''], kw: dict, bart: mc_gbart) -> dict:
         """Convert bartz keyword arguments to R BART3 keyword arguments."""

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -291,32 +291,32 @@ class TestWithCachedBart:  # pragma: slow
         with subtests.test('yhat_train'):
             yhat_train = bart.yhat_train.reshape(nchains, nsamples, n)
             rhat_yhat_train = rhat_rank(yhat_train, split=True)
-            assert_array_less(rhat_yhat_train, 6)
+            assert_array_less(rhat_yhat_train, 1.1)
 
         if get_with_default(kw, 'type') == 'pbart':  # binary regression
             with subtests.test('prob_train'):
                 prob_train = bart.prob_train.reshape(nchains, nsamples, n)
                 rhat_prob_train = rhat_rank(prob_train, split=True)
-                assert_array_less(rhat_prob_train, 1.2)
+                assert_array_less(rhat_prob_train, 1.01)
 
         else:  # continuous regression
             with subtests.test('sigma'):
                 sigma = bart.sigma[nsamples:, :].T
                 rhat_sigma = rhat_rank(sigma, split=True)
-                assert rhat_sigma < 1.2
+                assert_array_less(rhat_sigma, 1.01)
 
         if p < n:
             with subtests.test('varcount'):
                 varcount = bart.varcount.reshape(nchains, nsamples, p)
                 rhat_varcount = rhat_rank(varcount, split=True)
-                assert_array_less(rhat_varcount, 7)
+                assert_array_less(rhat_varcount, 1.8)
 
             if get_with_default(kw, 'sparse'):  # pragma: no branch
                 with subtests.test('varprob'):
                     varprob = bart.varprob.reshape(nchains, nsamples, p)
                     rhat_varprob = rhat_rank(varprob[:, :, 1:], split=True)
                     # drop one component because varprob sums to 1
-                    assert_array_less(rhat_varprob, 7)
+                    assert_array_less(rhat_varprob, 1.7)
 
     def kw_bartz_to_BART3(self, key: Key[Array, ''], kw: dict, bart: mc_gbart) -> dict:
         """Convert bartz keyword arguments to R BART3 keyword arguments."""
@@ -409,24 +409,24 @@ class TestWithCachedBart:  # pragma: slow
             rhat_yhat_train = rhat_rank(
                 [bart.yhat_train, rbart.yhat_train], split=False
             )
-            assert_array_less(rhat_yhat_train, 3.5)
+            assert_array_less(rhat_yhat_train, 1.05)
 
         with subtests.test('yhat_test'):
             rhat_yhat_test = rhat_rank([bart.yhat_test, rbart.yhat_test], split=False)
-            assert_array_less(rhat_yhat_test, 3.5)
+            assert_array_less(rhat_yhat_test, 1.05)
 
         if get_with_default(kw, 'type') == 'pbart':  # binary regression
             with subtests.test('prob_train'):
                 rhat_prob_train = rhat_rank(
                     [bart.prob_train, rbart.prob_train], split=False
                 )
-                assert_array_less(rhat_prob_train, 1.2)
+                assert_array_less(rhat_prob_train, 1.01)
 
             with subtests.test('prob_test'):
                 rhat_prob_test = rhat_rank(
                     [bart.prob_test, rbart.prob_test], split=False
                 )
-                assert_array_less(rhat_prob_test, 1.2)
+                assert_array_less(rhat_prob_test, 1.01)
 
         else:  # continuous regression
             with subtests.test('yhat_train_mean'):
@@ -448,7 +448,7 @@ class TestWithCachedBart:  # pragma: slow
                     [bart.sigma_[-bart.ndpost :], rbart.sigma_[-rbart.ndpost :]],
                     split=False,
                 )
-                assert rhat_sigma < 1.3
+                assert_array_less(rhat_sigma, 1.01)
 
             with subtests.test('sigma_mean'):
                 assert_allclose(bart.sigma_mean, rbart.sigma_mean, rtol=0.1)
@@ -458,7 +458,7 @@ class TestWithCachedBart:  # pragma: slow
             bart_count = bart.varcount.sum(axis=1)
             rbart_count = rbart.varcount.sum(axis=1)
             rhat_count = rhat_rank([bart_count, rbart_count], split=False)
-            assert rhat_count < 30  # genuinely bad, see below
+            assert_array_less(rhat_count, 2.5)  # genuinely bad, see below
             assert_allclose(bart_count.mean(), rbart_count.mean(), rtol=0.2)
 
         if p < n:
@@ -470,7 +470,7 @@ class TestWithCachedBart:  # pragma: slow
                 # there is a visible discrepancy on the number of nodes, with bartz
                 # having deeper trees, this 6 is not just "not good to sampling
                 # accuracy but close in practice."
-                assert_array_less(rhat_varcount, 7)
+                assert_array_less(rhat_varcount, 1.4)
 
             with subtests.test('varcount_mean'):
                 assert_close_matrices(
@@ -489,7 +489,7 @@ class TestWithCachedBart:  # pragma: slow
                         split=False,
                     )
                     # drop one component because varprob sums to 1
-                    assert_array_less(rhat_varprob, 4)
+                    assert_array_less(rhat_varprob, 1.3)
 
                 with subtests.test('varprob_mean'):
                     assert_close_matrices(
@@ -1024,7 +1024,7 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
         nstub_mcmc = count_stub_trees(bart._main_trace.split_tree)
         nstub_prior = count_stub_trees(prior_trace.split_tree)
         rhat_nstub = rhat_rank([nstub_mcmc, nstub_prior], split=False)
-        assert rhat_nstub < 1.01
+        assert_array_less(rhat_nstub, 1.01)
 
     if (p, nsplits) != (1, 1):
         # all the following are equivalent to nstub in the 1-1 case
@@ -1033,7 +1033,7 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
             nsimple_mcmc = count_simple_trees(bart._main_trace.split_tree)
             nsimple_prior = count_simple_trees(prior_trace.split_tree)
             rhat_nsimple = rhat_rank([nsimple_mcmc, nsimple_prior], split=False)
-            assert rhat_nsimple < 1.01
+            assert_array_less(rhat_nsimple, 1.01)
 
         varcount_prior = compute_varcount(
             bart._mcmc_state.forest.max_split.size, prior_trace
@@ -1041,11 +1041,7 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
 
         with subtests.test('varcount'):
             rhat_varcount = rhat_rank([bart.varcount, varcount_prior], split=False)
-            if p == 10:
-                # varcount is p-dimensional
-                assert_array_less(rhat_varcount, 1.4)
-            else:
-                assert_array_less(rhat_varcount, 1.2)
+            assert_array_less(rhat_varcount, 1.05)
 
         with subtests.test('number of nodes'):
             sum_varcount_mcmc = bart.varcount.sum(axis=1)
@@ -1053,32 +1049,32 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
             rhat_sum_varcount = rhat_rank(
                 [sum_varcount_mcmc, sum_varcount_prior], split=False
             )
-            assert rhat_sum_varcount < 1.05
+            assert_array_less(rhat_sum_varcount, 1.01)
 
         with subtests.test('imbalance index'):
             imb_mcmc = avg_imbalance_index(bart._main_trace.split_tree)
             imb_prior = avg_imbalance_index(prior_trace.split_tree)
             rhat_imb = rhat_rank([imb_mcmc, imb_prior], split=False)
-            assert rhat_imb < 1.02
+            assert_array_less(rhat_imb, 1.01)
 
         with subtests.test('average max tree depth'):
             maxd_mcmc = avg_max_tree_depth(bart._main_trace.split_tree)
             maxd_prior = avg_max_tree_depth(prior_trace.split_tree)
             rhat_maxd = rhat_rank([maxd_mcmc, maxd_prior], split=False)
-            assert rhat_maxd < 1.02
+            assert_array_less(rhat_maxd, 1.01)
 
         with subtests.test('max tree depth distribution'):
             dd_mcmc = bart.depth_distr()
             dd_prior = forest_depth_distr(prior_trace.split_tree)
             rhat_dd = rhat_rank([dd_mcmc.squeeze(0), dd_prior], split=False)
-            assert_array_less(rhat_dd, 1.05)
+            assert_array_less(rhat_dd, 1.02)
 
     with subtests.test('y_test'):
         X = random.randint(keys.pop(), (p, 30), 0, nsplits + 1)
         yhat_mcmc = bart._bart._predict(X)
         yhat_prior = evaluate_trace(X, prior_trace)
         rhat_yhat = rhat_rank([yhat_mcmc, yhat_prior], split=False)
-        assert_array_less(rhat_yhat, 1.1)
+        assert_array_less(rhat_yhat, 1.01)
 
 
 def run_bart_like_prior(

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -43,6 +43,7 @@ from jax.scipy.special import logit, ndtr
 from jax.sharding import Mesh, SingleDeviceSharding
 from jax.tree_util import KeyPath, keystr
 from jaxtyping import Array, Float32, Int32, Key, PyTree, Shaped, UInt
+from numpy.testing import assert_array_less
 from pytest_subtests import SubTests
 
 from bartz import Bart
@@ -79,6 +80,7 @@ from tests.util import (
     multivariate_rhat,
     periodic_sigint,
     rhat,
+    rhat_rank,
 )
 
 try:
@@ -1186,6 +1188,36 @@ def test_rhat(keys: split) -> None:
     rhat_divergent = multivariate_rhat(divergent_chains)
     assert rhat < 1.02
     assert rhat_divergent > 5
+
+
+def test_rhat_rank(keys: split) -> None:
+    """Test the rank-normalized split-Rhat port from arviz_stats."""
+    chains, divergent_chains = random.normal(keys.pop(), (2, 2, 1000, 10))
+    mean_offset = 10 * jnp.arange(len(chains))
+    divergent_chains += mean_offset[:, None, None]
+    rhat = rhat_rank(chains)
+    rhat_divergent = rhat_rank(divergent_chains)
+    assert rhat.shape == (10,)
+    assert rhat_divergent.shape == (10,)
+    assert_array_less(rhat, 1.01)
+    assert_array_less(1.3, rhat_divergent)
+
+
+def test_rhat_rank_axes(keys: split) -> None:
+    """Test ``rhat_rank`` honors ``chain_axis`` and ``draw_axis``."""
+    chains = random.normal(keys.pop(), (2, 1000, 5))
+    reference = rhat_rank(chains)
+    transposed = jnp.moveaxis(chains, (0, 1), (2, 0))
+    relocated = rhat_rank(transposed, chain_axis=2, draw_axis=0)
+    assert_allclose(relocated, reference, rtol=1e-12)
+
+
+def test_rhat_rank_shape_errors() -> None:
+    """Test ``rhat_rank`` rejects undersized chain/draw dimensions."""
+    with pytest.raises(ValueError, match='2 chains'):
+        rhat_rank(jnp.zeros((1, 200)))
+    with pytest.raises(ValueError, match='4 draws'):
+        rhat_rank(jnp.zeros((2, 3)))
 
 
 def test_jit(kw: dict[str, Any]) -> None:

--- a/tests/test_dgp.py
+++ b/tests/test_dgp.py
@@ -32,7 +32,7 @@ import pytest
 from jax import jit, random, vmap
 from jax import numpy as jnp
 from jaxtyping import Array, Bool, Float, Key
-from numpy.testing import assert_allclose, assert_array_equal, assert_array_less
+from numpy.testing import assert_array_less
 from scipy.stats import norm
 
 from bartz.jaxext import split
@@ -43,6 +43,7 @@ from bartz.testing._dgp import (
     interaction_pattern,
     partitioned_interaction_pattern,
 )
+from tests.util import assert_allclose, assert_array_equal
 
 # Test parameters
 ALPHA = 5e-7  # probability of false positive (aaaaapprox)
@@ -168,7 +169,7 @@ class TestGeneratePartition:
 
         # Each column should sum to 1
         col_sums = jnp.sum(partitions, axis=1)  # Shape: (N_REPS, P)
-        assert_array_equal(col_sums, 1)
+        assert_array_equal(col_sums, 1, strict=False)
 
     def test_partition_counts(self, dgps: DGP) -> None:
         """Test that counts are either p//c or p//c + 1."""
@@ -180,7 +181,7 @@ class TestGeneratePartition:
         # Each count should be either P//K or P//K + 1
         floor_count = p // k
         valid = (counts == floor_count) | (counts == floor_count + 1)
-        assert_array_equal(valid, True)
+        assert_array_equal(valid, True, strict=False)
 
     def test_partition_balance(self, dgps: DGP) -> None:
         """Test that predictors are roughly balanced across components."""
@@ -395,12 +396,12 @@ class TestInteractionPattern:
 
     def test_diagonal(self, pattern: Bool[Array, 'p p']) -> None:
         """Test that diagonal is True."""
-        assert_array_equal(jnp.diag(pattern), True)
+        assert_array_equal(jnp.diag(pattern), True, strict=False)
 
     def test_row_sums(self, pattern: Bool[Array, 'p p']) -> None:
         """Test that each row sums to q+1."""
         row_sums = jnp.sum(pattern, axis=1)
-        assert_array_equal(row_sums, 4 + 1)
+        assert_array_equal(row_sums, 4 + 1, strict=False)
 
 
 class TestPartitionedInteractionPattern:
@@ -429,7 +430,7 @@ class TestPartitionedInteractionPattern:
         # For each component, check that True values only occur where partition is True
         # pattern[i, r, s] can only be True if partition[i, r] and partition[i, s] are True
         mask = partition[:, :, None] & partition[:, None, :]  # Shape: (k, p, p)
-        assert_array_equal(pattern & ~mask, False)
+        assert_array_equal(pattern & ~mask, False, strict=False)
 
     def test_diagonal_within_partition(
         self, partition: Bool[Array, 'k p'], pattern: Bool[Array, 'k p p']
@@ -438,7 +439,7 @@ class TestPartitionedInteractionPattern:
         k, _, _ = pattern.shape
         for i in range(k):
             diagonal = pattern[i, partition[i], partition[i]]
-            assert_array_equal(diagonal, True)
+            assert_array_equal(diagonal, True, strict=False)
 
     def test_row_sums(
         self, pattern: Bool[Array, 'k p p'], partition: Bool[Array, 'k p'], q: int

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -84,6 +84,7 @@ from tests.util import (
     assert_array_equal,
     assert_close_matrices,
     assert_different_matrices,
+    clipped_logit,
     periodic_sigint,
     rhat_rank,
 )
@@ -512,8 +513,10 @@ class TestWithCachedBart:  # pragma: slow
             with subtests.test('prob_train'):
                 prob_train = bart.predict('train', kind='mean_samples')
                 prob_train_chains = prob_train.reshape(num_chains, nsamples, -1)
-                rhat_prob_train = rhat_rank(prob_train_chains, split=True)
-                assert_array_less(rhat_prob_train, 1.01)
+                rhat_prob_train = rhat_rank(
+                    clipped_logit(prob_train_chains, 1e-5), split=True
+                )
+                assert_array_less(rhat_prob_train, 1.005)
         elif mixed:
             with subtests.test('sigma'):
                 # mixed regression: check get_error_sdev, dropping binary

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -57,6 +57,7 @@ from jax import numpy as jnp
 from jax.sharding import Mesh, SingleDeviceSharding
 from jax.tree_util import KeyPath, keystr
 from jaxtyping import Array, Float32, Int32, Key, PyTree, Real, Shaped, UInt
+from numpy.testing import assert_array_less
 from pytest import FixtureRequest  # noqa: PT013
 from pytest_subtests import SubTests
 
@@ -83,9 +84,8 @@ from tests.util import (
     assert_array_equal,
     assert_close_matrices,
     assert_different_matrices,
-    multivariate_rhat,
     periodic_sigint,
-    rhat,
+    rhat_rank,
 )
 
 
@@ -504,16 +504,16 @@ class TestWithCachedBart:  # pragma: slow
         with subtests.test('yhat_train'):
             yhat_train = bart.predict('train', kind='latent_samples')
             yhat_train_chains = yhat_train.reshape(num_chains, nsamples, -1)
-            rhat_yhat_train = multivariate_rhat(yhat_train_chains)
-            assert rhat_yhat_train < 6
+            rhat_yhat_train = rhat_rank(yhat_train_chains, split=True)
+            assert_array_less(rhat_yhat_train, 6)
 
         mixed = isinstance(bkw.kw['outcome_type'], list)
         if binary:
             with subtests.test('prob_train'):
                 prob_train = bart.predict('train', kind='mean_samples')
                 prob_train_chains = prob_train.reshape(num_chains, nsamples, -1)
-                rhat_prob_train = multivariate_rhat(prob_train_chains)
-                assert rhat_prob_train < 1.2
+                rhat_prob_train = rhat_rank(prob_train_chains, split=True)
+                assert_array_less(rhat_prob_train, 1.2)
         elif mixed:
             with subtests.test('sigma'):
                 # mixed regression: check get_error_sdev, dropping binary
@@ -521,10 +521,12 @@ class TestWithCachedBart:  # pragma: slow
                 with debug_nans(False):
                     sigma = bart.get_error_sdev().reshape(num_chains, nsamples, -1)
                     binary_mask = bart._binary_mask
-                    if binary_mask.ndim > 0:  # pragma: no branch, always on in mv variants
+                    if (
+                        binary_mask.ndim > 0
+                    ):  # pragma: no branch, always on in mv variants
                         sigma = sigma[:, :, ~binary_mask]
-                rhat_sigma = multivariate_rhat(sigma)
-                assert rhat_sigma < 1.2
+                rhat_sigma = rhat_rank(sigma, split=True)
+                assert_array_less(rhat_sigma, 1.2)
         else:
             with subtests.test('error_cov_inv'):
                 # all continuous: check full precision matrix convergence
@@ -535,20 +537,20 @@ class TestWithCachedBart:  # pragma: slow
                 _, _, k, _ = error_cov_inv.shape
                 ti, tj = jnp.triu_indices(k)
                 error_cov_inv = error_cov_inv[:, :, ti, tj]
-                rhat_prec = multivariate_rhat(error_cov_inv)
-                assert rhat_prec < 1.2
+                rhat_prec = rhat_rank(error_cov_inv, split=True)
+                assert_array_less(rhat_prec, 1.2)
 
         if p < n:
             with subtests.test('varcount'):
                 varcount_vals = bart.varcount.reshape(num_chains, nsamples, p)
-                rhat_varcount = multivariate_rhat(varcount_vals)
-                assert rhat_varcount < 7
+                rhat_varcount = rhat_rank(varcount_vals, split=True)
+                assert_array_less(rhat_varcount, 7)
 
             if bkw.kw.get('sparse', False):  # pragma: no branch
                 with subtests.test('varprob'):
                     varprob_vals = bart.varprob.reshape(num_chains, nsamples, p)
-                    rhat_varprob = multivariate_rhat(varprob_vals[:, :, 1:])
-                    assert rhat_varprob < 7
+                    rhat_varprob = rhat_rank(varprob_vals[:, :, 1:], split=True)
+                    assert_array_less(rhat_varprob, 7)
 
     def test_different_chains(self, cachedbart: CachedBart) -> None:
         """Check that different chains give different results."""
@@ -1036,8 +1038,7 @@ def test_no_datapoints(bkw: BartKW) -> None:
         jnp.zeros_like(bart._burnin_trace.log_likelihood),
     )
     assert_array_equal(
-        bart._main_trace.log_likelihood,
-        jnp.zeros_like(bart._main_trace.log_likelihood),
+        bart._main_trace.log_likelihood, jnp.zeros_like(bart._main_trace.log_likelihood)
     )
 
 
@@ -1172,14 +1173,14 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
     with subtests.test('number of stub trees'):
         nstub_mcmc = count_stub_trees(bart._main_trace.split_tree)
         nstub_prior = count_stub_trees(prior_trace.split_tree)
-        rhat_nstub = rhat([nstub_mcmc, nstub_prior])
+        rhat_nstub = rhat_rank([nstub_mcmc, nstub_prior], split=False)
         assert rhat_nstub < 1.01
 
     if (p, nsplits) != (1, 1):
         with subtests.test('number of simple trees'):
             nsimple_mcmc = count_simple_trees(bart._main_trace.split_tree)
             nsimple_prior = count_simple_trees(prior_trace.split_tree)
-            rhat_nsimple = rhat([nsimple_mcmc, nsimple_prior])
+            rhat_nsimple = rhat_rank([nsimple_mcmc, nsimple_prior], split=False)
             assert rhat_nsimple < 1.01
 
         varcount_prior = compute_varcount(
@@ -1187,42 +1188,44 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
         )
 
         with subtests.test('varcount'):
-            rhat_varcount = multivariate_rhat([bart.varcount, varcount_prior])
+            rhat_varcount = rhat_rank([bart.varcount, varcount_prior], split=False)
             if p == 10:
-                assert rhat_varcount < 1.4
+                assert_array_less(rhat_varcount, 1.4)
             else:
-                assert rhat_varcount < 1.05
+                assert_array_less(rhat_varcount, 1.05)
 
         with subtests.test('number of nodes'):
             sum_varcount_mcmc = bart.varcount.sum(axis=1)
             sum_varcount_prior = varcount_prior.sum(axis=1)
-            rhat_sum_varcount = rhat([sum_varcount_mcmc, sum_varcount_prior])
+            rhat_sum_varcount = rhat_rank(
+                [sum_varcount_mcmc, sum_varcount_prior], split=False
+            )
             assert rhat_sum_varcount < 1.05
 
         with subtests.test('imbalance index'):
             imb_mcmc = avg_imbalance_index(bart._main_trace.split_tree)
             imb_prior = avg_imbalance_index(prior_trace.split_tree)
-            rhat_imb = rhat([imb_mcmc, imb_prior])
+            rhat_imb = rhat_rank([imb_mcmc, imb_prior], split=False)
             assert rhat_imb < 1.02
 
         with subtests.test('average max tree depth'):
             maxd_mcmc = avg_max_tree_depth(bart._main_trace.split_tree)
             maxd_prior = avg_max_tree_depth(prior_trace.split_tree)
-            rhat_maxd = rhat([maxd_mcmc, maxd_prior])
+            rhat_maxd = rhat_rank([maxd_mcmc, maxd_prior], split=False)
             assert rhat_maxd < 1.02
 
         with subtests.test('max tree depth distribution'):
             dd_mcmc = bart.depth_distr()
             dd_prior = forest_depth_distr(prior_trace.split_tree)
-            rhat_dd = multivariate_rhat([dd_mcmc.squeeze(0), dd_prior])
-            assert rhat_dd < 1.05
+            rhat_dd = rhat_rank([dd_mcmc.squeeze(0), dd_prior], split=False)
+            assert_array_less(rhat_dd, 1.05)
 
     with subtests.test('y_test'):
         X = random.randint(keys.pop(), (p, 30), 0, nsplits + 1)
         yhat_mcmc = bart._predict(X)
         yhat_prior = evaluate_trace(X, prior_trace)
-        rhat_yhat = multivariate_rhat([yhat_mcmc, yhat_prior])
-        assert rhat_yhat < 1.1
+        rhat_yhat = rhat_rank([yhat_mcmc, yhat_prior], split=False)
+        assert_array_less(rhat_yhat, 1.1)
 
 
 def run_bart_like_prior(

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -57,7 +57,6 @@ from jax import numpy as jnp
 from jax.sharding import Mesh, SingleDeviceSharding
 from jax.tree_util import KeyPath, keystr
 from jaxtyping import Array, Float32, Int32, Key, PyTree, Real, Shaped, UInt
-from numpy.testing import assert_allclose, assert_array_equal
 from pytest import FixtureRequest  # noqa: PT013
 from pytest_subtests import SubTests
 
@@ -80,6 +79,8 @@ from bartz.prepcovars import GivenSplitsBinner, RangeEvenBinner, UniqueQuantileB
 from tests.conftest import get_disable_problematic_sharding
 from tests.test_mcmcstep import check_sharding, get_normal_spec, normalize_spec
 from tests.util import (
+    assert_allclose,
+    assert_array_equal,
     assert_close_matrices,
     assert_different_matrices,
     multivariate_rhat,
@@ -852,8 +853,8 @@ class TestVarprobAttr:
             binner=partial(GivenSplitsBinner, xinfo=xinfo),
             seed=keys.pop(),
         )
-        assert_array_equal(bart._mcmc_state.forest.max_split, [0, 1])
-        assert_array_equal(bart.varprob_mean, [0, 1])
+        assert_array_equal(bart._mcmc_state.forest.max_split, [0, 1], strict=False)
+        assert_array_equal(bart.varprob_mean, [0, 1], strict=False)
         assert jnp.all(bart.varprob_mean == bart.varprob)
 
 
@@ -1011,7 +1012,7 @@ def test_no_datapoints(bkw: BartKW) -> None:
     k = kw['y_train'].shape[:-1]  # () or (k,)
     assert bart.predict('train', kind='latent_samples').shape == (ndpost, *k, 0)
 
-    assert_array_equal(bart.offset, 0)  # compare against jnp.zeros with strict=True
+    assert_array_equal(bart.offset, jnp.zeros_like(bart.offset))
     outcome_type = kw['outcome_type']
     if outcome_type == 'binary':
         tau_num = 3
@@ -1023,15 +1024,21 @@ def test_no_datapoints(bkw: BartKW) -> None:
         assert_array_equal(bart.sigest, expected_sigest)
     else:
         tau_num = 1
-        assert_array_equal(bart.sigest, 1)  # compare against jnp.ones with strict=True
+        assert_array_equal(bart.sigest, jnp.ones_like(bart.sigest))
     expected_cov_inv = jnp.float32((2**2 * kw['num_trees']) / tau_num**2)
     leaf_prior_cov_inv = bart._mcmc_state.forest.leaf_prior_cov_inv
     if leaf_prior_cov_inv.ndim == 2:  # pragma: no branch, always mv with defaults
         expected_cov_inv = jnp.eye(leaf_prior_cov_inv.shape[0]) * expected_cov_inv
     assert_close_matrices(leaf_prior_cov_inv, expected_cov_inv, rtol=1e-6)
 
-    assert_array_equal(bart._burnin_trace.log_likelihood, 0.0)
-    assert_array_equal(bart._main_trace.log_likelihood, 0.0)
+    assert_array_equal(
+        bart._burnin_trace.log_likelihood,
+        jnp.zeros_like(bart._burnin_trace.log_likelihood),
+    )
+    assert_array_equal(
+        bart._main_trace.log_likelihood,
+        jnp.zeros_like(bart._main_trace.log_likelihood),
+    )
 
 
 def test_one_datapoint(bkw: BartKW) -> None:
@@ -1135,7 +1142,7 @@ def test_xinfo() -> None:
 
     xinfo_wo_nan = jnp.where(jnp.isnan(xinfo), jnp.finfo(jnp.float32).max, xinfo)
     assert_array_equal(bart._binner._splits, xinfo_wo_nan)
-    assert_array_equal(bart._mcmc_state.forest.max_split, [2, 3, 0])
+    assert_array_equal(bart._mcmc_state.forest.max_split, [2, 3, 0], strict=False)
 
 
 def test_xinfo_wrong_p() -> None:
@@ -1242,8 +1249,14 @@ def run_bart_like_prior(
     )
 
     with subtests.test('likelihood ratio = 1'):
-        assert_array_equal(bart._burnin_trace.log_likelihood, 0.0)
-        assert_array_equal(bart._main_trace.log_likelihood, 0.0)
+        assert_array_equal(
+            bart._burnin_trace.log_likelihood,
+            jnp.zeros_like(bart._burnin_trace.log_likelihood),
+        )
+        assert_array_equal(
+            bart._main_trace.log_likelihood,
+            jnp.zeros_like(bart._main_trace.log_likelihood),
+        )
 
     return bart
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -505,7 +505,7 @@ class TestWithCachedBart:  # pragma: slow
             yhat_train = bart.predict('train', kind='latent_samples')
             yhat_train_chains = yhat_train.reshape(num_chains, nsamples, -1)
             rhat_yhat_train = rhat_rank(yhat_train_chains, split=True)
-            assert_array_less(rhat_yhat_train, 6)
+            assert_array_less(rhat_yhat_train, 1.05)
 
         mixed = isinstance(bkw.kw['outcome_type'], list)
         if binary:
@@ -513,7 +513,7 @@ class TestWithCachedBart:  # pragma: slow
                 prob_train = bart.predict('train', kind='mean_samples')
                 prob_train_chains = prob_train.reshape(num_chains, nsamples, -1)
                 rhat_prob_train = rhat_rank(prob_train_chains, split=True)
-                assert_array_less(rhat_prob_train, 1.2)
+                assert_array_less(rhat_prob_train, 1.01)
         elif mixed:
             with subtests.test('sigma'):
                 # mixed regression: check get_error_sdev, dropping binary
@@ -526,7 +526,7 @@ class TestWithCachedBart:  # pragma: slow
                     ):  # pragma: no branch, always on in mv variants
                         sigma = sigma[:, :, ~binary_mask]
                 rhat_sigma = rhat_rank(sigma, split=True)
-                assert_array_less(rhat_sigma, 1.2)
+                assert_array_less(rhat_sigma, 1.01)
         else:
             with subtests.test('error_cov_inv'):
                 # all continuous: check full precision matrix convergence
@@ -538,19 +538,19 @@ class TestWithCachedBart:  # pragma: slow
                 ti, tj = jnp.triu_indices(k)
                 error_cov_inv = error_cov_inv[:, :, ti, tj]
                 rhat_prec = rhat_rank(error_cov_inv, split=True)
-                assert_array_less(rhat_prec, 1.2)
+                assert_array_less(rhat_prec, 1.01)
 
         if p < n:
             with subtests.test('varcount'):
                 varcount_vals = bart.varcount.reshape(num_chains, nsamples, p)
                 rhat_varcount = rhat_rank(varcount_vals, split=True)
-                assert_array_less(rhat_varcount, 7)
+                assert_array_less(rhat_varcount, 1.4)
 
             if bkw.kw.get('sparse', False):  # pragma: no branch
                 with subtests.test('varprob'):
                     varprob_vals = bart.varprob.reshape(num_chains, nsamples, p)
                     rhat_varprob = rhat_rank(varprob_vals[:, :, 1:], split=True)
-                    assert_array_less(rhat_varprob, 7)
+                    assert_array_less(rhat_varprob, 1.3)
 
     def test_different_chains(self, cachedbart: CachedBart) -> None:
         """Check that different chains give different results."""
@@ -1174,14 +1174,14 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
         nstub_mcmc = count_stub_trees(bart._main_trace.split_tree)
         nstub_prior = count_stub_trees(prior_trace.split_tree)
         rhat_nstub = rhat_rank([nstub_mcmc, nstub_prior], split=False)
-        assert rhat_nstub < 1.01
+        assert_array_less(rhat_nstub, 1.01)
 
     if (p, nsplits) != (1, 1):
         with subtests.test('number of simple trees'):
             nsimple_mcmc = count_simple_trees(bart._main_trace.split_tree)
             nsimple_prior = count_simple_trees(prior_trace.split_tree)
             rhat_nsimple = rhat_rank([nsimple_mcmc, nsimple_prior], split=False)
-            assert rhat_nsimple < 1.01
+            assert_array_less(rhat_nsimple, 1.01)
 
         varcount_prior = compute_varcount(
             bart._mcmc_state.forest.max_split.size, prior_trace
@@ -1190,9 +1190,9 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
         with subtests.test('varcount'):
             rhat_varcount = rhat_rank([bart.varcount, varcount_prior], split=False)
             if p == 10:
-                assert_array_less(rhat_varcount, 1.4)
-            else:
                 assert_array_less(rhat_varcount, 1.05)
+            else:
+                assert_array_less(rhat_varcount, 1.02)
 
         with subtests.test('number of nodes'):
             sum_varcount_mcmc = bart.varcount.sum(axis=1)
@@ -1200,32 +1200,32 @@ def test_prior(keys: split, p: int, nsplits: int, subtests: SubTests) -> None:
             rhat_sum_varcount = rhat_rank(
                 [sum_varcount_mcmc, sum_varcount_prior], split=False
             )
-            assert rhat_sum_varcount < 1.05
+            assert_array_less(rhat_sum_varcount, 1.02)
 
         with subtests.test('imbalance index'):
             imb_mcmc = avg_imbalance_index(bart._main_trace.split_tree)
             imb_prior = avg_imbalance_index(prior_trace.split_tree)
             rhat_imb = rhat_rank([imb_mcmc, imb_prior], split=False)
-            assert rhat_imb < 1.02
+            assert_array_less(rhat_imb, 1.02)
 
         with subtests.test('average max tree depth'):
             maxd_mcmc = avg_max_tree_depth(bart._main_trace.split_tree)
             maxd_prior = avg_max_tree_depth(prior_trace.split_tree)
             rhat_maxd = rhat_rank([maxd_mcmc, maxd_prior], split=False)
-            assert rhat_maxd < 1.02
+            assert_array_less(rhat_maxd, 1.02)
 
         with subtests.test('max tree depth distribution'):
             dd_mcmc = bart.depth_distr()
             dd_prior = forest_depth_distr(prior_trace.split_tree)
             rhat_dd = rhat_rank([dd_mcmc.squeeze(0), dd_prior], split=False)
-            assert_array_less(rhat_dd, 1.05)
+            assert_array_less(rhat_dd, 1.02)
 
     with subtests.test('y_test'):
         X = random.randint(keys.pop(), (p, 30), 0, nsplits + 1)
         yhat_mcmc = bart._predict(X)
         yhat_prior = evaluate_trace(X, prior_trace)
         rhat_yhat = rhat_rank([yhat_mcmc, yhat_prior], split=False)
-        assert_array_less(rhat_yhat, 1.1)
+        assert_array_less(rhat_yhat, 1.01)
 
 
 def run_bart_like_prior(

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1930,7 +1930,7 @@ def test_sigest_cg(bkw: BartKW) -> None:
     bart_ols = Bart(**dict(bkw.kw, sigest='ols-or-variance'))
     bart_cg = Bart(**dict(bkw.kw, sigest='cg'))
     mask = ~bart_ols._binary_mask
-    assert_close_matrices(bart_cg.sigest[mask], bart_ols.sigest[mask])
+    assert_close_matrices(bart_cg.sigest[mask], bart_ols.sigest[mask], rtol=1e-6)
 
 
 def test_sigest_auto_cg(keys: split) -> None:

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -492,7 +492,7 @@ class TestWithCachedBart:  # pragma: slow
         )
         assert_close_matrices(accum_resid, actual_resid, rtol=1e-4, reduce_rank=True)
 
-    def test_convergence(self, cachedbart: CachedBart) -> None:
+    def test_convergence(self, cachedbart: CachedBart, subtests: SubTests) -> None:
         """Run multiple chains and check convergence with rhat."""
         bart = cachedbart.bart
         bkw = cachedbart.bkw
@@ -501,54 +501,54 @@ class TestWithCachedBart:  # pragma: slow
         nsamples = bart.n_save
         binary = bkw.kw['outcome_type'] == 'binary'
 
-        yhat_train = bart.predict('train', kind='latent_samples')
-        yhat_train_chains = yhat_train.reshape(num_chains, nsamples, -1)
-        rhat_yhat_train = multivariate_rhat(yhat_train_chains)
-        assert rhat_yhat_train < 6
-        print(f'{rhat_yhat_train.item()=}')
+        with subtests.test('yhat_train'):
+            yhat_train = bart.predict('train', kind='latent_samples')
+            yhat_train_chains = yhat_train.reshape(num_chains, nsamples, -1)
+            rhat_yhat_train = multivariate_rhat(yhat_train_chains)
+            assert rhat_yhat_train < 6
 
         mixed = isinstance(bkw.kw['outcome_type'], list)
         if binary:
-            prob_train = bart.predict('train', kind='mean_samples')
-            prob_train_chains = prob_train.reshape(num_chains, nsamples, -1)
-            rhat_prob_train = multivariate_rhat(prob_train_chains)
-            assert rhat_prob_train < 1.2
-            print(f'{rhat_prob_train.item()=}')
+            with subtests.test('prob_train'):
+                prob_train = bart.predict('train', kind='mean_samples')
+                prob_train_chains = prob_train.reshape(num_chains, nsamples, -1)
+                rhat_prob_train = multivariate_rhat(prob_train_chains)
+                assert rhat_prob_train < 1.2
         elif mixed:
-            # mixed regression: check get_error_sdev, dropping binary
-            # components (NaN sdev)
-            with debug_nans(False):
-                sigma = bart.get_error_sdev().reshape(num_chains, nsamples, -1)
-                binary_mask = bart._binary_mask
-                if binary_mask.ndim > 0:  # pragma: no branch, always on in mv variants
-                    sigma = sigma[:, :, ~binary_mask]
-            rhat_sigma = multivariate_rhat(sigma)
-            assert rhat_sigma < 1.2
-            print(f'{rhat_sigma.item()=}')
+            with subtests.test('sigma'):
+                # mixed regression: check get_error_sdev, dropping binary
+                # components (NaN sdev)
+                with debug_nans(False):
+                    sigma = bart.get_error_sdev().reshape(num_chains, nsamples, -1)
+                    binary_mask = bart._binary_mask
+                    if binary_mask.ndim > 0:  # pragma: no branch, always on in mv variants
+                        sigma = sigma[:, :, ~binary_mask]
+                rhat_sigma = multivariate_rhat(sigma)
+                assert rhat_sigma < 1.2
         else:
-            # all continuous: check full precision matrix convergence
-            # using upper triangular elements (matrix is symmetric)
-            error_cov_inv = bart._main_trace.error_cov_inv
-            if error_cov_inv.ndim == 2:  # pragma: no cover, only mv by default
-                error_cov_inv = error_cov_inv[:, :, None, None]
-            _, _, k, _ = error_cov_inv.shape
-            ti, tj = jnp.triu_indices(k)
-            error_cov_inv = error_cov_inv[:, :, ti, tj]
-            rhat_prec = multivariate_rhat(error_cov_inv)
-            assert rhat_prec < 1.2
-            print(f'{rhat_prec.item()=}')
+            with subtests.test('error_cov_inv'):
+                # all continuous: check full precision matrix convergence
+                # using upper triangular elements (matrix is symmetric)
+                error_cov_inv = bart._main_trace.error_cov_inv
+                if error_cov_inv.ndim == 2:  # pragma: no cover, only mv by default
+                    error_cov_inv = error_cov_inv[:, :, None, None]
+                _, _, k, _ = error_cov_inv.shape
+                ti, tj = jnp.triu_indices(k)
+                error_cov_inv = error_cov_inv[:, :, ti, tj]
+                rhat_prec = multivariate_rhat(error_cov_inv)
+                assert rhat_prec < 1.2
 
         if p < n:
-            varcount_vals = bart.varcount.reshape(num_chains, nsamples, p)
-            rhat_varcount = multivariate_rhat(varcount_vals)
-            assert rhat_varcount < 7
-            print(f'{rhat_varcount.item()=}')
+            with subtests.test('varcount'):
+                varcount_vals = bart.varcount.reshape(num_chains, nsamples, p)
+                rhat_varcount = multivariate_rhat(varcount_vals)
+                assert rhat_varcount < 7
 
             if bkw.kw.get('sparse', False):  # pragma: no branch
-                varprob_vals = bart.varprob.reshape(num_chains, nsamples, p)
-                rhat_varprob = multivariate_rhat(varprob_vals[:, :, 1:])
-                assert rhat_varprob < 7
-                print(f'{rhat_varprob.item()=}')
+                with subtests.test('varprob'):
+                    varprob_vals = bart.varprob.reshape(num_chains, nsamples, p)
+                    rhat_varprob = multivariate_rhat(varprob_vals[:, :, 1:])
+                    assert rhat_varprob < 7
 
     def test_different_chains(self, cachedbart: CachedBart) -> None:
         """Check that different chains give different results."""

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -991,62 +991,12 @@ def test_min_points_per_leaf(bkw: BartKW) -> None:
         assert distr_marg[min_points] > 0
 
 
-def test_no_datapoints(bkw: BartKW) -> None:
-    """Check automatic data scaling with 0 datapoints."""
-    kw = set_num_datapoints(bkw.kw, 0)
+@pytest.mark.parametrize('num_datapoints', [0, 1])
+def test_zero_or_one_datapoint(bkw: BartKW, num_datapoints: int) -> None:
+    """Check automatic data scaling with 0 or 1 datapoints."""
+    kw = set_num_datapoints(bkw.kw, num_datapoints)
 
-    p, _ = kw['x_train'].shape
-    nsplits = 10
-    xinfo = jnp.broadcast_to(jnp.arange(nsplits, dtype=jnp.float32), (p, nsplits))
-    kw.update(binner=partial(GivenSplitsBinner, xinfo=xinfo))
-
-    kw.update(num_data_devices=None)
-
-    init_kw = dict(kw.get('init_kw', {}))
-    init_kw.update(
-        save_ratios=True, min_points_per_decision_node=None, min_points_per_leaf=None
-    )
-    kw['init_kw'] = init_kw
-
-    bart = Bart(**kw)
-
-    ndpost = bart.ndpost
-    k = kw['y_train'].shape[:-1]  # () or (k,)
-    assert bart.predict('train', kind='latent_samples').shape == (ndpost, *k, 0)
-
-    assert_array_equal(bart.offset, jnp.zeros_like(bart.offset))
-    outcome_type = kw['outcome_type']
-    if outcome_type == 'binary':
-        tau_num = 3
-        assert bart.sigest is None
-    elif isinstance(outcome_type, Sequence) and not isinstance(outcome_type, str):
-        binary_mask = jnp.array([t == 'binary' for t in outcome_type])
-        tau_num = jnp.where(binary_mask, 3.0, 1.0)
-        expected_sigest = jnp.where(binary_mask, 0.0, 1.0)
-        assert_array_equal(bart.sigest, expected_sigest)
-    else:
-        tau_num = 1
-        assert_array_equal(bart.sigest, jnp.ones_like(bart.sigest))
-    expected_cov_inv = jnp.float32((2**2 * kw['num_trees']) / tau_num**2)
-    leaf_prior_cov_inv = bart._mcmc_state.forest.leaf_prior_cov_inv
-    if leaf_prior_cov_inv.ndim == 2:  # pragma: no branch, always mv with defaults
-        expected_cov_inv = jnp.eye(leaf_prior_cov_inv.shape[0]) * expected_cov_inv
-    assert_close_matrices(leaf_prior_cov_inv, expected_cov_inv, rtol=1e-6)
-
-    assert_array_equal(
-        bart._burnin_trace.log_likelihood,
-        jnp.zeros_like(bart._burnin_trace.log_likelihood),
-    )
-    assert_array_equal(
-        bart._main_trace.log_likelihood, jnp.zeros_like(bart._main_trace.log_likelihood)
-    )
-
-
-def test_one_datapoint(bkw: BartKW) -> None:
-    """Check automatic data scaling with 1 datapoint."""
-    kw = set_num_datapoints(bkw.kw, 1)
-
-    if bkw.uses_quantile_binner:
+    if num_datapoints == 0 or bkw.uses_quantile_binner:
         p, _ = kw['x_train'].shape
         nsplits = 10
         xinfo = jnp.broadcast_to(jnp.arange(nsplits, dtype=jnp.float32), (p, nsplits))
@@ -1063,29 +1013,45 @@ def test_one_datapoint(bkw: BartKW) -> None:
     bart = Bart(**kw)
     outcome_type = kw['outcome_type']
     k = kw['y_train'].shape[:-1]  # () or (k,)
+
+    assert bart.predict('train', kind='latent_samples').shape == (
+        bart.ndpost,
+        *k,
+        num_datapoints,
+    )
+
+    # check bart.offset
+    mask = bart._binary_mask
+    if num_datapoints == 0 or outcome_type == 'binary':
+        assert_array_equal(bart.offset, jnp.zeros_like(bart.offset))
+    else:
+        assert_allclose(
+            bart.offset[..., None],
+            jnp.where(mask[..., None], 0.0, kw['y_train']),
+            rtol=1e-6,
+        )
+
+    # check bart.sigest and set expected tau_num
     if outcome_type == 'binary':
         tau_num = 3
         assert bart.sigest is None
-        assert_array_equal(bart.offset, jnp.zeros(k), strict=True)
-    elif isinstance(outcome_type, Sequence) and not isinstance(outcome_type, str):
-        binary_mask = jnp.array([t == 'binary' for t in outcome_type])
-        tau_num = jnp.where(binary_mask, 3.0, 1.0)
-        expected_sigest = jnp.where(binary_mask, 0.0, 1.0)
-        assert_array_equal(bart.sigest, expected_sigest)
     else:
-        tau_num = 1
-        assert_array_equal(bart.sigest, jnp.ones(k), strict=True)
-        assert_close_matrices(bart.offset[..., None], kw['y_train'], rtol=1e-6)
+        tau_num = jnp.where(mask, 3.0, 1.0)
+        expected_sigest = jnp.where(mask, 0.0, 1.0)
+        assert_array_equal(bart.sigest, expected_sigest)
+
+    # check leaf_prior_cov_inv
     expected_cov_inv = (2**2 * kw['num_trees']) / tau_num**2
     leaf_prior_cov_inv = bart._mcmc_state.forest.leaf_prior_cov_inv
     if leaf_prior_cov_inv.ndim == 2:  # pragma: no branch, always mv with defaults
         expected_cov_inv = jnp.eye(leaf_prior_cov_inv.shape[0]) * expected_cov_inv
-    assert_allclose(leaf_prior_cov_inv, expected_cov_inv, rtol=1e-6)
+    assert_close_matrices(leaf_prior_cov_inv, expected_cov_inv, rtol=1e-6)
 
-    # in the multivariate case, it's not exactly 0 because matrix inversion
-    # adds an epsilon to handle ill-conditioned matrices
-    assert_allclose(bart._burnin_trace.log_likelihood, 0.0, atol=1e-6)
-    assert_allclose(bart._main_trace.log_likelihood, 0.0, atol=1e-6)
+    # with 1 datapoint in the multivariate case, log_likelihood is not exactly 0
+    # because matrix inversion adds an epsilon to handle ill-conditioned matrices
+    atol = 0.0 if num_datapoints == 0 else 1e-6
+    assert_allclose(bart._burnin_trace.log_likelihood, 0.0, atol=atol)
+    assert_allclose(bart._main_trace.log_likelihood, 0.0, atol=atol)
 
 
 def test_two_datapoints(bkw: BartKW) -> None:

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -889,68 +889,104 @@ def test_variable_selection(keys: split, theta: Literal['fixed', 'free']) -> Non
 
 
 def test_scale_shift(bkw: BartKW) -> None:
-    """Check self-consistency of rescaling the inputs."""
+    """Check self-consistency of rescaling the inputs.
+
+    For mixed binary-continuous outcomes, only the continuous components
+    of `y_train` are rescaled, and binary components are matched between
+    `bart1` and `bart2` via `bart._binary_mask`.
+    """
     kw = bkw.kw
-    outcome_type = kw['outcome_type']
-    if outcome_type == 'binary' or (
-        isinstance(outcome_type, Sequence)
-        and not isinstance(outcome_type, str)
-        and any(t == 'binary' for t in outcome_type)
-    ):
-        pytest.skip('Cannot rescale binary responses.')
 
     bart1 = Bart(**kw)
+    mask = bart1._binary_mask
+    if mask.all():
+        pytest.skip('Cannot rescale binary responses.')
 
     offset = 0.4703189
     scale = 0.5294714
+
+    y = kw['y_train']
+    y = jnp.where(mask[..., None], y, offset + y * scale)
+
     kw2 = dict(kw)
-    kw2.update(y_train=offset + kw['y_train'] * scale, seed=random.clone(kw['seed']))
+    kw2.update(y_train=y, seed=random.clone(kw['seed']))
     bart2 = Bart(**kw2)
 
-    assert_allclose(bart1.offset, (bart2.offset - offset) / scale, rtol=1e-6, atol=1e-6)
-    assert_allclose(
-        bart1._mcmc_state.forest.leaf_prior_cov_inv,
-        bart2._mcmc_state.forest.leaf_prior_cov_inv * scale**2,
-        rtol=1e-6,
-        atol=0,
+    assert_close_matrices(
+        bart1.offset,
+        jnp.where(mask, bart2.offset, (bart2.offset - offset) / scale),
+        rtol=1e-5,
     )
-    assert_allclose(bart1.sigest, bart2.sigest / scale, rtol=1e-6)
+    assert_close_matrices(
+        bart1.sigest, jnp.where(mask, bart2.sigest, bart2.sigest / scale), rtol=1e-6
+    )
     assert_array_equal(bart1._mcmc_state.error_cov_df, bart2._mcmc_state.error_cov_df)
-    assert_allclose(
-        bart1._mcmc_state.error_cov_scale,
-        bart2._mcmc_state.error_cov_scale / scale**2,
+
+    masked_scale = jnp.where(mask, 1.0, scale)
+    if masked_scale.ndim:
+        masked_scale = masked_scale[:, None]
+    cov_scale = masked_scale * masked_scale.T
+
+    assert_close_matrices(
+        bart1._mcmc_state.forest.leaf_prior_cov_inv,
+        bart2._mcmc_state.forest.leaf_prior_cov_inv * cov_scale,
         rtol=1e-6,
     )
+
+    assert_close_matrices(
+        bart1._mcmc_state.error_cov_scale * cov_scale,
+        bart2._mcmc_state.error_cov_scale,
+        rtol=1e-6,
+    )
+
+    mask_pred = mask[..., None]
 
     yhat1 = bart1.predict('train', kind='latent_samples')
     yhat2 = bart2.predict('train', kind='latent_samples')
-    assert_close_matrices(yhat1, (yhat2 - offset) / scale, rtol=1e-5, reduce_rank=True)
+    assert_close_matrices(
+        yhat1,
+        jnp.where(mask_pred, yhat2, (yhat2 - offset) / scale),
+        rtol=1e-5,
+        reduce_rank=True,
+    )
 
     mean1 = bart1.predict('train', kind='mean')
     mean2 = bart2.predict('train', kind='mean')
-    assert_close_matrices(mean1, (mean2 - offset) / scale, rtol=1e-5, reduce_rank=True)
+    assert_close_matrices(
+        mean1,
+        jnp.where(mask_pred, mean2, (mean2 - offset) / scale),
+        rtol=1e-5,
+        reduce_rank=True,
+    )
 
     yhat_test1 = bart1.predict(kw['x_train'], kind='latent_samples')
     yhat_test2 = bart2.predict(kw['x_train'], kind='latent_samples')
     assert_close_matrices(
-        yhat_test1, (yhat_test2 - offset) / scale, rtol=1e-5, reduce_rank=True
+        yhat_test1,
+        jnp.where(mask_pred, yhat_test2, (yhat_test2 - offset) / scale),
+        rtol=1e-5,
+        reduce_rank=True,
     )
 
     yhat_test_mean1 = bart1.predict(kw['x_train'], kind='mean')
     yhat_test_mean2 = bart2.predict(kw['x_train'], kind='mean')
     assert_close_matrices(
-        yhat_test_mean1, (yhat_test_mean2 - offset) / scale, rtol=1e-5, reduce_rank=True
+        yhat_test_mean1,
+        jnp.where(mask_pred, yhat_test_mean2, (yhat_test_mean2 - offset) / scale),
+        rtol=1e-5,
+        reduce_rank=True,
     )
 
-    sdev1 = bart1.get_error_sdev()
-    sdev2 = bart2.get_error_sdev()
-    assert_close_matrices(sdev1, sdev2 / scale, rtol=1e-5, reduce_rank=True)
-    assert_allclose(
-        bart1.get_error_sdev(mean=True),
-        bart2.get_error_sdev(mean=True) / scale,
-        rtol=1e-6,
-        atol=1e-6,
-    )
+    # binary positions of get_error_sdev are NaN; replace with 0 to compare.
+    with debug_nans(False):
+        sdev_actual = jnp.where(mask, 0.0, bart1.get_error_sdev())
+        sdev_expected = jnp.where(mask, 0.0, bart2.get_error_sdev() / scale)
+        sdev_mean_actual = jnp.where(mask, 0.0, bart1.get_error_sdev(mean=True))
+        sdev_mean_expected = jnp.where(
+            mask, 0.0, bart2.get_error_sdev(mean=True) / scale
+        )
+    assert_close_matrices(sdev_actual, sdev_expected, rtol=1e-5, reduce_rank=True)
+    assert_close_matrices(sdev_mean_actual, sdev_mean_expected, rtol=1e-6)
 
 
 def test_min_points_per_decision_node(bkw: BartKW) -> None:

--- a/tests/test_jaxext.py
+++ b/tests/test_jaxext.py
@@ -52,7 +52,6 @@ from jax import numpy as jnp
 from jax.scipy.special import ndtri
 from jax.sharding import AxisType, Mesh, PartitionSpec
 from jaxtyping import Array, Float, Float32, Key, Shaped
-from numpy.testing import assert_allclose, assert_array_equal
 from pytest_subtests import SubTests
 from scipy.stats import invgamma as scipy_invgamma
 from scipy.stats import ks_1samp, truncnorm
@@ -61,7 +60,7 @@ from bartz import jaxext
 from bartz.jaxext import equal_shards, split
 from bartz.jaxext.scipy.special import ndtri as patched_ndtri
 from bartz.jaxext.scipy.stats import invgamma
-from tests.util import assert_close_matrices
+from tests.util import assert_allclose, assert_array_equal, assert_close_matrices
 
 
 class TestUnique:
@@ -71,7 +70,7 @@ class TestUnique:
         """Check that it's equivalent to sort if no values are repeated."""
         x = jnp.arange(10)[::-1]
         out, length = jaxext.unique(x, x.size, 666)
-        numpy.testing.assert_array_equal(jnp.sort(x), out)
+        assert_array_equal(jnp.sort(x), out)
         assert out.dtype == x.dtype
         assert length == x.size
 
@@ -79,7 +78,7 @@ class TestUnique:
         """Check that the trailing fill value is used correctly."""
         x = jnp.ones(10)
         out, length = jaxext.unique(x, x.size, 666)
-        numpy.testing.assert_array_equal([1] + 9 * [666], out)
+        assert_array_equal(jnp.asarray([1.0] + 9 * [666.0]), out)
         assert out.dtype == x.dtype
         assert length == 1
 
@@ -87,7 +86,7 @@ class TestUnique:
         """Check that the function works on empty input."""
         x = jnp.array([])
         out, length = jaxext.unique(x, 2, 666)
-        numpy.testing.assert_array_equal([666, 666], out)
+        assert_array_equal(jnp.asarray([666.0, 666.0]), out)
         assert out.dtype == x.dtype
         assert length == 0
 
@@ -95,7 +94,7 @@ class TestUnique:
         """Check that the function works if the output is forced to be empty."""
         x = jnp.array([1, 1, 1])
         out, length = jaxext.unique(x, 0, 666)
-        numpy.testing.assert_array_equal([], out)
+        assert_array_equal(jnp.zeros(0, dtype=x.dtype), out)
         assert out.dtype == x.dtype
         assert length == 0
 

--- a/tests/test_mcmcloop.py
+++ b/tests/test_mcmcloop.py
@@ -35,13 +35,13 @@ from jax import numpy as jnp
 from jax.sharding import AxisType, PartitionSpec
 from jax.tree_util import KeyPath
 from jaxtyping import Array, Float32, UInt8
-from numpy.testing import assert_array_equal
 from pytest import FixtureRequest  # noqa: PT013
 
 from bartz.jaxext import get_default_device, split
 from bartz.mcmcloop import BurninTrace, MainTrace, run_mcmc
 from bartz.mcmcstep import State, init, make_p_nonterminal
 from bartz.mcmcstep._state import chain_vmap_axes
+from tests.util import assert_array_equal
 
 
 def gen_data(

--- a/tests/test_mcmcstep.py
+++ b/tests/test_mcmcstep.py
@@ -49,7 +49,6 @@ from jaxtyping import (
     UInt32,
     jaxtyped,
 )
-from numpy.testing import assert_allclose, assert_array_equal
 from pytest import FixtureRequest  # noqa: PT013
 from pytest_subtests import SubTests
 from scipy import stats
@@ -79,7 +78,12 @@ from bartz.mcmcstep._step import (
     step_trees,
     step_z,
 )
-from tests.util import assert_close_matrices, manual_tree
+from tests.util import (
+    assert_allclose,
+    assert_array_equal,
+    assert_close_matrices,
+    manual_tree,
+)
 
 
 class VarTreeData(NamedTuple):
@@ -209,7 +213,7 @@ class TestAncestorVariables:
         result = ancestor_variables(var_tree, max_split, jnp.int32(1))
         # var_tree size=4 -> tree_depth=2 -> max_num_ancestors=1
         # All slots should be p (sentinel) since root has no ancestors
-        assert_array_equal(result, [max_split.size])
+        assert_array_equal(result, [max_split.size], strict=False)
 
     def test_child_of_root(self, depth2_tree: VarTreeData) -> None:
         """Check that children of root have one ancestor (the root's variable)."""
@@ -218,11 +222,11 @@ class TestAncestorVariables:
         # Left child of root (index 2): ancestor is root (var=2)
         result = ancestor_variables(var_tree, max_split, jnp.int32(2))
         assert result.shape == (1,)
-        assert_array_equal(result, [2])
+        assert_array_equal(result, [2], strict=False)
 
         # Right child of root (index 3): ancestor is root (var=2)
         result = ancestor_variables(var_tree, max_split, jnp.int32(3))
-        assert_array_equal(result, [2])
+        assert_array_equal(result, [2], strict=False)
 
     def test_deep_node(self, depth3_tree: VarTreeData) -> None:
         """Check ancestors for nodes at depth 3."""
@@ -231,19 +235,19 @@ class TestAncestorVariables:
         # Node 4: parent is 2 (var=2), grandparent is 1 (var=3)
         result = ancestor_variables(var_tree, max_split, jnp.int32(4))
         assert result.shape == (2,)
-        assert_array_equal(result, [3, 2])
+        assert_array_equal(result, [3, 2], strict=False)
 
         # Node 5: parent is 2 (var=2), grandparent is 1 (var=3)
         result = ancestor_variables(var_tree, max_split, jnp.int32(5))
-        assert_array_equal(result, [3, 2])
+        assert_array_equal(result, [3, 2], strict=False)
 
         # Node 6: parent is 3 (var=1), grandparent is 1 (var=3)
         result = ancestor_variables(var_tree, max_split, jnp.int32(6))
-        assert_array_equal(result, [3, 1])
+        assert_array_equal(result, [3, 1], strict=False)
 
         # Node 7: parent is 3 (var=1), grandparent is 1 (var=3)
         result = ancestor_variables(var_tree, max_split, jnp.int32(7))
-        assert_array_equal(result, [3, 1])
+        assert_array_equal(result, [3, 1], strict=False)
 
     def test_intermediate_node(self, depth3_tree: VarTreeData) -> None:
         """Check ancestors for an intermediate (non-leaf) node."""
@@ -251,11 +255,11 @@ class TestAncestorVariables:
 
         # Node 2: parent is 1 (var=3), one slot filled, one sentinel
         result = ancestor_variables(var_tree, max_split, jnp.int32(2))
-        assert_array_equal(result, [max_split.size, 3])
+        assert_array_equal(result, [max_split.size, 3], strict=False)
 
         # Node 3: parent is 1 (var=3), one slot filled, one sentinel
         result = ancestor_variables(var_tree, max_split, jnp.int32(3))
-        assert_array_equal(result, [max_split.size, 3])
+        assert_array_equal(result, [max_split.size, 3], strict=False)
 
     def test_single_variable(self) -> None:
         """Check with only one variable (p=1)."""
@@ -267,11 +271,11 @@ class TestAncestorVariables:
 
         # Node 2: ancestor is root (var=0)
         result = ancestor_variables(var_tree, max_split, jnp.int32(2))
-        assert_array_equal(result, [0])
+        assert_array_equal(result, [0], strict=False)
 
         # Root has no ancestors
         result = ancestor_variables(var_tree, max_split, jnp.int32(1))
-        assert_array_equal(result, [max_split.size])
+        assert_array_equal(result, [max_split.size], strict=False)
 
     def test_type_edge(self, depth3_tree: VarTreeData) -> None:
         """Check that types are handled correctly when using uint8 and uint16 together."""
@@ -282,11 +286,11 @@ class TestAncestorVariables:
 
         # Node 2: parent is 1 (var=3), one slot filled, one sentinel
         result = ancestor_variables(var_tree, max_split, jnp.int32(2))
-        assert_array_equal(result, [max_split.size, 3])
+        assert_array_equal(result, [max_split.size, 3], strict=False)
 
         # Node 3: parent is 1 (var=3), one slot filled, one sentinel
         result = ancestor_variables(var_tree, max_split, jnp.int32(3))
-        assert_array_equal(result, [max_split.size, 3])
+        assert_array_equal(result, [max_split.size, 3], strict=False)
 
 
 class TestRandintExclude:

--- a/tests/test_prepcovars.py
+++ b/tests/test_prepcovars.py
@@ -31,7 +31,6 @@ from functools import partial
 import pytest
 from jax import Array, debug_infs, random
 from jax import numpy as jnp
-from numpy.testing import assert_array_equal
 
 from bartz.jaxext import split
 from bartz.prepcovars import (
@@ -47,7 +46,7 @@ from bartz.prepcovars import (
     _subsample,
     _uniform_splits_from_matrix,
 )
-from tests.util import assert_close_matrices
+from tests.util import assert_array_equal, assert_close_matrices
 
 
 class TestQuantilizer:
@@ -63,20 +62,20 @@ class TestQuantilizer:
             x = jnp.array([[1, 1, 3, 3], [1, 3, 3, 5], [1, 3, 5, 7]], fill_value.dtype)
             splits, _ = _quantilized_splits_from_matrix(x, 100)
         expected_splits = [[2, fill_value, fill_value], [2, 4, fill_value], [2, 4, 6]]
-        assert_array_equal(splits, expected_splits)
+        assert_array_equal(splits, expected_splits, strict=False)
 
     def test_max_splits(self) -> None:
         """Check that the number of splits per predictor is counted correctly."""
         x = jnp.array([[1, 1, 1, 1], [4, 4, 1, 1], [2, 1, 3, 2], [1, 4, 2, 3]])
         _, max_split = _quantilized_splits_from_matrix(x, 100)
-        assert_array_equal(max_split, jnp.arange(4))
+        assert_array_equal(max_split, jnp.arange(4), strict=False)
 
     def test_integer_splits_overflow(self) -> None:
         """Check that the splits are computed correctly at the limit of overflow."""
         x = jnp.array([[-(2**31), 2**31 - 2]])
         splits, _ = _quantilized_splits_from_matrix(x, 100)
         expected_splits = [[-1]]
-        assert_array_equal(splits, expected_splits)
+        assert_array_equal(splits, expected_splits, strict=False)
 
     @pytest.mark.parametrize('dtype', [int, float])
     def test_splits_type(self, dtype: type) -> None:
@@ -106,13 +105,13 @@ class TestQuantilizer:
         x = jnp.arange(10)[None, :]
         splits, _ = _quantilized_splits_from_matrix(x, 100)
         b = _bin_predictors(x, splits)
-        assert_array_equal(x, b)
+        assert_array_equal(x, b, strict=False)
 
     def test_one_value(self) -> None:
         """Check there's only 1 bin (0 splits) if there is 1 datapoint."""
         x = jnp.arange(10)[:, None]
         _, max_split = _quantilized_splits_from_matrix(x, 100)
-        assert_array_equal(max_split, jnp.full(len(x), 0))
+        assert_array_equal(max_split, jnp.full(len(x), 0), strict=False)
 
     def test_zero_values(self) -> None:
         """Check what happens when no binning is possible."""
@@ -316,7 +315,7 @@ def test_binner_left_boundary() -> None:
 
     x = jnp.array([[0, 1]])
     b = _bin_predictors(x, splits)
-    assert_array_equal(b, [[0, 0]])
+    assert_array_equal(b, [[0, 0]], strict=False)
 
 
 def test_binner_right_boundary() -> None:
@@ -325,7 +324,7 @@ def test_binner_right_boundary() -> None:
 
     x = jnp.array([[2**31 - 1]])
     b = _bin_predictors(x, splits)
-    assert_array_equal(b, [[3]])
+    assert_array_equal(b, [[3]], strict=False)
 
 
 class TestSigma2Estimates:

--- a/tests/util.py
+++ b/tests/util.py
@@ -36,7 +36,8 @@ from typing import Any
 
 import numpy as np
 from jax import numpy as jnp
-from jaxtyping import ArrayLike, Float
+from jax.scipy.special import logit
+from jaxtyping import Array, ArrayLike, Float
 from numpy.testing import assert_allclose as _np_assert_allclose  # noqa: TID251
 from numpy.testing import assert_array_equal as _np_assert_array_equal  # noqa: TID251
 from scipy import linalg, stats
@@ -277,6 +278,11 @@ def periodic_sigint(
     finally:
         if timer._thread is not None:
             timer.cancel()
+
+
+def clipped_logit(x: ArrayLike, eps: float) -> Array:
+    """Compute the logit of x, clipping x to [eps, 1-eps] to avoid infinities."""
+    return logit(jnp.clip(x, eps, 1 - eps))
 
 
 def rhat_rank(

--- a/tests/util.py
+++ b/tests/util.py
@@ -36,9 +36,7 @@ from typing import Any
 
 import numpy as np
 from jax import numpy as jnp
-from jax import vmap
-from jax.scipy.linalg import solve_triangular
-from jaxtyping import Array, ArrayLike, Float, Real
+from jaxtyping import ArrayLike, Float
 from numpy.testing import assert_allclose as _np_assert_allclose  # noqa: TID251
 from numpy.testing import assert_array_equal as _np_assert_array_equal  # noqa: TID251
 from scipy import linalg, stats
@@ -216,64 +214,6 @@ def assert_array_equal(
     _np_assert_array_equal(actual, desired, strict=strict, **kwargs)
 
 
-def multivariate_rhat(chains: Real[Array, 'chain sample dim']) -> Float[Array, '']:
-    """Compute the multivariate Gelman-Rubin R-hat.
-
-    Parameters
-    ----------
-    chains
-        Independent chains of samples of a vector, shape ``(m, n, p)``.
-
-    Returns
-    -------
-    The maximum eigenvalue of ``W^{-1} V_hat``, which generalizes R-hat.
-
-    Raises
-    ------
-    ValueError
-        If there are not enough chains or samples.
-    """
-    chains = jnp.asarray(chains)
-    m, n, p = chains.shape
-
-    if m < 2:  # pragma: no cover
-        msg = 'Need at least 2 chains'
-        raise ValueError(msg)
-    if n < 2:  # pragma: no cover
-        msg = 'Need at least 2 samples per chain'
-        raise ValueError(msg)
-
-    chain_means = jnp.mean(chains, axis=1)
-
-    def compute_chain_cov(
-        chain_samples: Float[Array, 'sample dim'], chain_mean: Float[Array, ' dim']
-    ) -> Float[Array, 'dim dim']:
-        centered = chain_samples - chain_mean
-        return jnp.dot(centered.T, centered) / (n - 1)
-
-    within_chain_covs = vmap(compute_chain_cov)(chains, chain_means)
-    W = jnp.mean(within_chain_covs, axis=0)
-
-    overall_mean = jnp.mean(chain_means, axis=0)
-    chain_mean_diffs = chain_means - overall_mean
-    B = (n / (m - 1)) * jnp.dot(chain_mean_diffs.T, chain_mean_diffs)
-
-    V_hat = ((n - 1) / n) * W + ((m + 1) / (m * n)) * B
-
-    # Add regularization to W for numerical stability
-    gershgorin = jnp.max(jnp.sum(jnp.abs(W), axis=1))
-    regularization = jnp.finfo(W.dtype).eps * len(W) * gershgorin
-    W_reg = W + regularization * jnp.eye(p)
-
-    # Compute max(eigvals(W^-1 V_hat))
-    L = jnp.linalg.cholesky(W_reg)
-    L_1V = solve_triangular(L, V_hat, lower=True)
-    L_1VL_T = solve_triangular(L, L_1V.T, lower=True).T
-    eigenvals = jnp.linalg.eigvalsh(L_1VL_T)
-
-    return jnp.max(eigenvals)
-
-
 class PeriodicSigintTimer:
     """Periodically send SIGINT (^C) to the main thread.
 
@@ -339,28 +279,8 @@ def periodic_sigint(
             timer.cancel()
 
 
-def rhat(chains: Real[Array, 'chain sample']) -> Float[Array, '']:
-    """Compute the univariate Gelman-Rubin R-hat.
-
-    Parameters
-    ----------
-    chains
-        Independent chains of samples of a scalar, shape ``(m, n)``.
-
-    Returns
-    -------
-    The univariate R-hat statistic.
-    """
-    chains = jnp.asarray(chains)
-    return multivariate_rhat(chains[:, :, None])
-
-
 def rhat_rank(
-    data: ArrayLike,
-    *,
-    split: bool,
-    chain_axis: int = 0,
-    draw_axis: int = 1,
+    data: ArrayLike, *, split: bool, chain_axis: int = 0, draw_axis: int = 1
 ) -> Float[np.ndarray, ' *leading']:
     """Elementwise rank-normalized (split-)Rhat.
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -356,9 +356,13 @@ def rhat(chains: Real[Array, 'chain sample']) -> Float[Array, '']:
 
 
 def rhat_rank(
-    data: ArrayLike, *, chain_axis: int = 0, draw_axis: int = 1
+    data: ArrayLike,
+    *,
+    split: bool,
+    chain_axis: int = 0,
+    draw_axis: int = 1,
 ) -> Float[np.ndarray, ' *leading']:
-    """Elementwise rank-normalized split-Rhat.
+    """Elementwise rank-normalized (split-)Rhat.
 
     Port of ``arviz_stats.rhat`` with ``method='rank'``, the rank-normalized
     folded split-Rhat of Vehtari et al. (2021),
@@ -369,6 +373,11 @@ def rhat_rank(
     data
         Array of MCMC draws with chains along ``chain_axis`` and draws along
         ``draw_axis``.
+    split
+        If True, split each chain in half along the draw axis before computing
+        Rhat (the standard rank-normalized split-Rhat). If False, skip the
+        split step and compute the rank-normalized Rhat on the chains as
+        given.
     chain_axis
     draw_axis
         Axes of ``data`` indexing chains and draws. Default to the arviz
@@ -377,28 +386,29 @@ def rhat_rank(
     Returns
     -------
     Array with ``chain_axis`` and ``draw_axis`` of ``data`` removed; each entry
-    is the rank-normalized split-Rhat over the corresponding (chain, draw)
+    is the rank-normalized (split-)Rhat over the corresponding (chain, draw)
     slice. NaNs in a slice propagate to ``nan`` in its Rhat.
 
     Raises
     ------
     ValueError
         If the chain dimension has fewer than 2 entries, or the draw dimension
-        fewer than 4.
+        has fewer than 4 (with ``split=True``) or 2 (with ``split=False``).
     """
     ary = np.asarray(data, float)
     ary = np.moveaxis(ary, (chain_axis, draw_axis), (-2, -1))
     *_, n_chain, n_draw = ary.shape
-    if n_chain < 2 or n_draw < 4:
+    min_draw = 4 if split else 2
+    if n_chain < 2 or n_draw < min_draw:
         msg = (
-            f'need at least 2 chains and 4 draws, got {n_chain} chains and '
-            f'{n_draw} draws'
+            f'need at least 2 chains and {min_draw} draws, got {n_chain} '
+            f'chains and {n_draw} draws'
         )
         raise ValueError(msg)
 
-    split = _split_chains_v(ary)
-    rhat_bulk = _rhat_v(_z_scale_v(split))
-    folded = np.abs(split - np.median(split, axis=(-2, -1), keepdims=True))
+    prepared = _split_chains_v(ary) if split else ary
+    rhat_bulk = _rhat_v(_z_scale_v(prepared))
+    folded = np.abs(prepared - np.median(prepared, axis=(-2, -1), keepdims=True))
     rhat_tail = _rhat_v(_z_scale_v(folded))
     return np.maximum(rhat_bulk, rhat_tail)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -39,6 +39,8 @@ from jax import numpy as jnp
 from jax import vmap
 from jax.scipy.linalg import solve_triangular
 from jaxtyping import Array, ArrayLike, Float, Real
+from numpy.testing import assert_allclose as _np_assert_allclose  # noqa: TID251
+from numpy.testing import assert_array_equal as _np_assert_array_equal  # noqa: TID251
 from scipy import linalg
 
 from bartz.grove import TreesTrace, check_trace, describe_error
@@ -193,6 +195,25 @@ def assert_different_matrices(*args: ArrayLike, **kwargs: Any) -> None:
     default_kwargs: dict = dict(rtol=np.inf, atol=np.inf)
     default_kwargs.update(kwargs)
     assert_close_matrices(*args, negate=True, **default_kwargs)
+
+
+def assert_allclose(
+    actual: ArrayLike,
+    desired: ArrayLike,
+    *,
+    rtol: float = 0.0,
+    atol: float = 0.0,
+    **kwargs: Any,
+) -> None:
+    """Wrap `numpy.testing.assert_allclose` with zero default tolerances."""
+    _np_assert_allclose(actual, desired, rtol=rtol, atol=atol, **kwargs)
+
+
+def assert_array_equal(
+    actual: ArrayLike, desired: ArrayLike, *, strict: bool = True, **kwargs: Any
+) -> None:
+    """Wrap `numpy.testing.assert_array_equal` with `strict=True` default."""
+    _np_assert_array_equal(actual, desired, strict=strict, **kwargs)
 
 
 def multivariate_rhat(chains: Real[Array, 'chain sample dim']) -> Float[Array, '']:

--- a/tests/util.py
+++ b/tests/util.py
@@ -41,7 +41,7 @@ from jax.scipy.linalg import solve_triangular
 from jaxtyping import Array, ArrayLike, Float, Real
 from numpy.testing import assert_allclose as _np_assert_allclose  # noqa: TID251
 from numpy.testing import assert_array_equal as _np_assert_array_equal  # noqa: TID251
-from scipy import linalg
+from scipy import linalg, stats
 
 from bartz.grove import TreesTrace, check_trace, describe_error
 from bartz.jaxext import minimal_unsigned_dtype
@@ -353,3 +353,81 @@ def rhat(chains: Real[Array, 'chain sample']) -> Float[Array, '']:
     """
     chains = jnp.asarray(chains)
     return multivariate_rhat(chains[:, :, None])
+
+
+def rhat_rank(
+    data: ArrayLike, *, chain_axis: int = 0, draw_axis: int = 1
+) -> Float[np.ndarray, ' *leading']:
+    """Elementwise rank-normalized split-Rhat.
+
+    Port of ``arviz_stats.rhat`` with ``method='rank'``, the rank-normalized
+    folded split-Rhat of Vehtari et al. (2021),
+    https://arxiv.org/abs/1903.08008. Vectorized over the leading shape.
+
+    Parameters
+    ----------
+    data
+        Array of MCMC draws with chains along ``chain_axis`` and draws along
+        ``draw_axis``.
+    chain_axis
+    draw_axis
+        Axes of ``data`` indexing chains and draws. Default to the arviz
+        ``(chain, draw, ...)`` layout.
+
+    Returns
+    -------
+    Array with ``chain_axis`` and ``draw_axis`` of ``data`` removed; each entry
+    is the rank-normalized split-Rhat over the corresponding (chain, draw)
+    slice. NaNs in a slice propagate to ``nan`` in its Rhat.
+
+    Raises
+    ------
+    ValueError
+        If the chain dimension has fewer than 2 entries, or the draw dimension
+        fewer than 4.
+    """
+    ary = np.asarray(data, float)
+    ary = np.moveaxis(ary, (chain_axis, draw_axis), (-2, -1))
+    *_, n_chain, n_draw = ary.shape
+    if n_chain < 2 or n_draw < 4:
+        msg = (
+            f'need at least 2 chains and 4 draws, got {n_chain} chains and '
+            f'{n_draw} draws'
+        )
+        raise ValueError(msg)
+
+    split = _split_chains_v(ary)
+    rhat_bulk = _rhat_v(_z_scale_v(split))
+    folded = np.abs(split - np.median(split, axis=(-2, -1), keepdims=True))
+    rhat_tail = _rhat_v(_z_scale_v(folded))
+    return np.maximum(rhat_bulk, rhat_tail)
+
+
+def _split_chains_v(
+    ary: Float[np.ndarray, '*leading chain draw'],
+) -> Float[np.ndarray, '*leading two_chain half_draw']:
+    """Split each chain in half along the draw axis; stack along chain axis."""
+    half = ary.shape[-1] // 2
+    return np.concatenate([ary[..., :half], ary[..., -half:]], axis=-2)
+
+
+def _z_scale_v(
+    ary: Float[np.ndarray, '*leading chain draw'],
+) -> Float[np.ndarray, '*leading chain draw']:
+    """Rank-normalize jointly over the last two axes (chain, draw)."""
+    flat = ary.reshape(*ary.shape[:-2], -1)
+    rank = stats.rankdata(flat, method='average', axis=-1)
+    z = stats.norm.ppf((rank - 3 / 8) / (rank.shape[-1] + 1 / 4))
+    return z.reshape(ary.shape)
+
+
+def _rhat_v(
+    ary: Float[np.ndarray, '*leading chain draw'],
+) -> Float[np.ndarray, ' *leading']:
+    """Classic Gelman-Rubin Rhat reducing the last two ``(chain, draw)`` axes."""
+    n = ary.shape[-1]
+    chain_mean = ary.mean(axis=-1)
+    chain_var = ary.var(axis=-1, ddof=1)
+    between = n * chain_mean.var(axis=-1, ddof=1)
+    within = chain_var.mean(axis=-1)
+    return np.sqrt((between / within + n - 1) / n)


### PR DESCRIPTION
- **fix: add tolerance to test_sigest_gc**
- **refactor: numpy.testing strict wrappers**
- **refactor: use subtests in test_convergence**
- **test: replace multivariate_rhat with rhat_rank**
- **refactor: remove N_VARIANTS from test_BART.py**
- **test: test_scale_shift checks mixed outcome types**
- **refactor: merge test_zero/one_datapoint**
- **test: make conftest version barriers specific**
- **test: compare `yhat_*_mean` w.r.t. posterior std**
- **test: compare probabilities in logit scale**
