### PR TITLE
feat: add sequential_unroll option to step

### DIFF
--- a/scripts/opt-unroll.jsonc
+++ b/scripts/opt-unroll.jsonc
@@ -1,0 +1,35 @@
+{
+    // Tune the unroll of the per-tree accept/reject scan in `step`.
+    //
+    // num_trees is FIXED, not scanned: the scanned loop body is identical for
+    // every tree, so the per-iteration cost (hence the best unroll) does not
+    // depend on the number of trees. We only need it to be a common multiple of
+    // every unroll value below (so each setting tiles the loop with no scan
+    // remainder) and large enough to time more than one block of the largest
+    // unroll. 32 satisfies both.
+    //
+    // maxdepth is fixed at 6, the value we use in practice; it would affect the
+    // loop body (tree size = 2^depth sets the n-independent per-node work) but
+    // we never vary it.
+    //
+    // The axes that change the loop body and that we do vary are scanned: n (the
+    // O(n) residual reduction that dominates the body for large n and vanishes
+    // for small n, where loop overhead is what unroll removes), the outcome
+    // dimension k, and weights (which adds a multiply of the residual vector by
+    // the weights inside the loop). The iterations carry `resid`, so they are
+    // sequentially dependent and unroll buys overhead/scheduling, not
+    // cross-iteration parallelism. count/prec batching and num_chains act
+    // outside this loop and are left at their defaults.
+    "plot": {
+        "scan": "n",
+        "reduce": "sequential_unroll",
+    },
+    "values": {
+        "n":                  [16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576],
+        "k":                  [null, 4],
+        "maxdepth":           [6],
+        "weights":            [false, true],
+        "num_trees":          [32],
+        "sequential_unroll":  [1, 2, 4, 8, 16],
+    },
+}

--- a/scripts/opt.py
+++ b/scripts/opt.py
@@ -42,6 +42,7 @@ The config file is a JSONC document like:
             "resid_num_batches":  [null, 1, 2, 4, 8],
             "count_num_batches":  [null],
             "prec_num_batches":   [null],
+            "sequential_unroll":  [1, 2, 4],
             "num_chains":         [null, 4]
         }
     }
@@ -139,6 +140,9 @@ class ConfigParams:
     prec_num_batches: int | None | Literal['auto'] = init_default('prec_num_batches')
     """`init`'s ``prec_num_batches`` kwarg."""
 
+    sequential_unroll: int | bool = init_default('sequential_unroll')
+    """`init`'s ``sequential_unroll`` kwarg."""
+
     num_chains: int | None = init_default('num_chains')
     """`init`'s ``num_chains`` kwarg."""
 
@@ -230,6 +234,7 @@ class ConfigParams:
             resid_num_batches=self.resid_num_batches,
             count_num_batches=self.count_num_batches,
             prec_num_batches=self.prec_num_batches,
+            sequential_unroll=self.sequential_unroll,
             num_chains=self.num_chains,
         )
 
@@ -259,6 +264,7 @@ class InitKwargs:
     resid_num_batches: int | None | Literal['auto']
     count_num_batches: int | None | Literal['auto']
     prec_num_batches: int | None | Literal['auto']
+    sequential_unroll: int | bool
     num_chains: int | None
 
     def init(self) -> State:

--- a/src/bartz/mcmcstep/_state.py
+++ b/src/bartz/mcmcstep/_state.py
@@ -552,7 +552,7 @@ def init(
     count_num_batches: int | None | Literal['auto'] = 'auto',
     prec_num_batches: int | None | Literal['auto'] = 'auto',
     prec_count_num_trees: int | None | Literal['auto'] = 'auto',
-    sequential_unroll: int | bool = 1,
+    sequential_unroll: int | bool = 2,
     save_ratios: bool = False,
     filter_splitless_vars: int = 0,
     min_points_per_leaf: int | Integer[ArrayLike, ''] | None = None,
@@ -634,8 +634,8 @@ def init(
     sequential_unroll
         How much to unroll the sequential accept/reject loop over trees in
         `step`. See the ``unroll`` argument of `jax.lax.scan`. Unrolling may
-        speed up the MCMC at the cost of longer compilation. 1 (default) means
-        no unrolling.
+        speed up the MCMC at the cost of longer compilation. 1 means no
+        unrolling; the default is 2.
     save_ratios
         Whether to save the Metropolis-Hastings ratios.
     filter_splitless_vars

--- a/src/bartz/mcmcstep/_state.py
+++ b/src/bartz/mcmcstep/_state.py
@@ -216,6 +216,10 @@ class StepConfig(Module):
     prec_count_num_trees: int | None = field(static=True)
     """Batch size for processing trees to compute count and prec trees."""
 
+    sequential_unroll: int | bool = field(static=True)
+    """How much to unroll the sequential accept/reject loop over trees in
+    `step`. See the ``unroll`` argument of `jax.lax.scan`."""
+
     mesh: Mesh | None = field(static=True)
     """The mesh used to shard data and computation across multiple devices."""
 
@@ -548,6 +552,7 @@ def init(
     count_num_batches: int | None | Literal['auto'] = 'auto',
     prec_num_batches: int | None | Literal['auto'] = 'auto',
     prec_count_num_trees: int | None | Literal['auto'] = 'auto',
+    sequential_unroll: int | bool = 1,
     save_ratios: bool = False,
     filter_splitless_vars: int = 0,
     min_points_per_leaf: int | Integer[ArrayLike, ''] | None = None,
@@ -626,6 +631,11 @@ def init(
         computing the likelihood precision. If `None`, do all trees at once,
         which may use too much memory. If 'auto' (default), it's chosen
         automatically.
+    sequential_unroll
+        How much to unroll the sequential accept/reject loop over trees in
+        `step`. See the ``unroll`` argument of `jax.lax.scan`. Unrolling may
+        speed up the MCMC at the cost of longer compilation. 1 (default) means
+        no unrolling.
     save_ratios
         Whether to save the Metropolis-Hastings ratios.
     filter_splitless_vars
@@ -841,6 +851,7 @@ def init(
             config=StepConfig(
                 steps_done=jnp.int32(0),
                 sparse_on_at=_asarray_or_none(sparse_on_at),
+                sequential_unroll=sequential_unroll,
                 mesh=mesh,
                 **red_cfg,
             ),

--- a/src/bartz/mcmcstep/_step.py
+++ b/src/bartz/mcmcstep/_step.py
@@ -1097,7 +1097,9 @@ def accept_moves_sequential_stage(pso: ParallelStageOut) -> tuple[State, Moves]:
         pso.prelkv,
         pso.prelf,
     )
-    resid, (leaf_trees, acc, to_prune, lkratio) = lax.scan(loop, pso.state.resid, pts)
+    resid, (leaf_trees, acc, to_prune, lkratio) = lax.scan(
+        loop, pso.state.resid, pts, unroll=pso.state.config.sequential_unroll
+    )
 
     state = replace(
         pso.state,

--- a/tests/test_mcmcstep.py
+++ b/tests/test_mcmcstep.py
@@ -126,6 +126,7 @@ def _minimal_step_config() -> StepConfig:
         count_num_batches=None,
         prec_num_batches=None,
         prec_count_num_trees=None,
+        sequential_unroll=1,
         mesh=None,
     )
 


### PR DESCRIPTION
## Summary

Adds a `sequential_unroll` knob that controls the `unroll` of the `jax.lax.scan` over trees in the per-tree accept/reject loop of `step` (`accept_moves_sequential_stage`).

- `mcmcstep.init` gains a `sequential_unroll: int | bool = 2` argument, stored on `StepConfig` (static field) and threaded into the `lax.scan` call.
- The scan iterations carry `resid` and are sequentially dependent, so unrolling buys loop-overhead/scheduling improvements rather than cross-iteration parallelism. It can speed up the MCMC at the cost of longer compilation.
- Default is 2 (1 = no unrolling).

## Benchmarking

- `scripts/opt.py` exposes `sequential_unroll` as a tunable `ConfigParams` field so it can be swept like the other `init` kwargs.
- `scripts/opt-unroll.jsonc` adds a config to tune the unroll across `n`, `k`, and `weights`, holding `num_trees`/`maxdepth` fixed (see the file's comments for the rationale).

## Tests

- `tests/test_mcmcstep.py`: the minimal `StepConfig` fixture sets `sequential_unroll=1`.

## Notes

This PR was authored by Claude Code on behalf of @Gattocrucco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)