### PR TITLE
feat: windowed MCMC diagnostics with effective-predictor reporting

### DIFF
--- a/src/bartz/mcmcloop/__init__.py
+++ b/src/bartz/mcmcloop/__init__.py
@@ -32,6 +32,8 @@ and `make_tqdm_callback`.
 
 from bartz.mcmcloop._callback import (
     PrintCallbackState,
+    StatsAccumulator,
+    StatsReport,
     TqdmCallbackState,
     make_print_callback,
     make_tqdm_callback,

--- a/src/bartz/mcmcloop/_callback.py
+++ b/src/bartz/mcmcloop/_callback.py
@@ -27,12 +27,12 @@
 import itertools
 from collections.abc import Callable
 from dataclasses import dataclass, replace
-from functools import wraps
+from functools import partial, wraps
 from typing import Any, TypeVar
 
 import numpy
-from equinox import Module
-from jax import debug, lax, tree
+from equinox import Module, field
+from jax import debug, eval_shape, lax, tree
 from jax import numpy as jnp
 from jax.nn import logmeanexp
 from jax.scipy.special import logsumexp
@@ -45,11 +45,150 @@ from bartz.mcmcstep import State
 from bartz.mcmcstep._axes import chain_to_axis, chain_vmap_axes, chainful_axis
 
 
+class StatsReport(Module):
+    """Forest diagnostics produced by `StatsAccumulator.report` for one report."""
+
+    grow_prop: Float32[Array, '']
+    """Fraction of trees proposed for a grow move."""
+
+    move_acc: Float32[Array, '']
+    """Fraction of trees on which a grow or prune move was accepted."""
+
+    mean_leaves: Float32[Array, '']
+    """Mean number of leaves per tree."""
+
+    peff: Float32[Array, ''] | None
+    """Effective number of predictors, or `None` when variable selection is off."""
+
+    n_samples: Int32[Array, ''] | None
+    """Number of iterations averaged over, or `None` when not averaging."""
+
+    num_chains: int | None = field(static=True)
+    """Number of chains averaged over, or `None` when single-chain."""
+
+    max_leaves: int = field(static=True)
+    """Maximum possible number of leaves per tree."""
+
+    p: int | None = field(static=True)
+    """Number of predictors, or `None` when variable selection is off."""
+
+
+class StatsAccumulator(Module):
+    """Running average of the forest diagnostics shown during the MCMC.
+
+    When enabled, it sums the per-iteration statistics so a report shows their
+    average over the iterations since the previous report. When disabled it
+    carries no running state and a report shows the latest iteration only.
+    """
+
+    sums: dict[str, Float32[Array, '']] | None
+    """Running sums of the averaged statistics, or `None` when disabled."""
+
+    count: Int32[Array, '']
+    """Number of iterations accumulated since the last reset."""
+
+    @classmethod
+    def initial(cls, state: State, *, enabled: bool) -> 'StatsAccumulator':
+        """Create a zeroed accumulator, inert unless `enabled`."""
+        if enabled:
+            # only the structure is needed, so avoid computing the statistics
+            shapes = eval_shape(cls._avg_stats, state)
+            sums = tree.map(lambda s: jnp.zeros(s.shape, s.dtype), shapes)
+        else:
+            sums = None
+        return cls(sums=sums, count=jnp.int32(0))
+
+    def update(self, state: State) -> 'StatsAccumulator':
+        """Add the latest iteration's statistics; no-op when disabled."""
+        if self.sums is None:
+            return self
+        sums = tree.map(jnp.add, self.sums, self._avg_stats(state))
+        return replace(self, sums=sums, count=self.count + 1)
+
+    def reset_if(self, cond: bool | Bool[Array, '']) -> 'StatsAccumulator':
+        """Zero the running sums where `cond` holds; no-op when disabled."""
+        if self.sums is None:
+            return self
+        sums = tree.map(lambda s: jnp.where(cond, 0, s), self.sums)
+        return replace(self, sums=sums, count=jnp.where(cond, 0, self.count))
+
+    def report(self, state: State) -> StatsReport:
+        """Statistics to display: the windowed average if enabled, else the latest."""
+        if self.sums is None:
+            averaged = self._avg_stats(state)
+            n_samples = None
+        else:
+            averaged = tree.map(lambda s: s / self.count, self.sums)
+            n_samples = self.count
+        return StatsReport(**averaged, **self._static_stats(state), n_samples=n_samples)
+
+    @staticmethod
+    def _avg_stats(state: State) -> dict[str, Float32[Array, ''] | None]:
+        """Per-iteration diagnostics that are averaged over the report window."""
+        forest = state.forest
+        chain_axis = chain_vmap_axes(forest).split_tree
+        num_trees_axis = chainful_axis(0, chain_axis)  # (num_trees, hts)
+        split_tree = chain_to_axis(forest.split_tree, chain_axis)
+        prop_total = forest.split_tree.shape[num_trees_axis]
+
+        log_s = forest.log_s
+        if log_s is None:
+            peff = None
+        else:
+            log_s = chain_to_axis(log_s, chain_vmap_axes(forest).log_s)
+            peff = StatsAccumulator._effective_predictors(log_s)
+
+        return dict(
+            grow_prop=forest.grow_prop_count.mean() / prop_total,
+            move_acc=(forest.grow_acc_count.mean() + forest.prune_acc_count.mean())
+            / prop_total,
+            mean_leaves=forest_mean_leaves(split_tree),
+            peff=peff,
+        )
+
+    @staticmethod
+    def _static_stats(state: State) -> dict[str, int | None]:
+        """Per-iteration diagnostics shown as-is, constant over the run."""
+        forest = state.forest
+        split_tree = chain_to_axis(
+            forest.split_tree, chain_vmap_axes(forest).split_tree
+        )
+        log_s = forest.log_s
+        if log_s is None:
+            p = None
+        else:
+            *_, p = chain_to_axis(log_s, chain_vmap_axes(forest).log_s).shape
+        return dict(num_chains=state.num_chains(), max_leaves=split_tree.shape[-1], p=p)
+
+    @staticmethod
+    def _effective_predictors(log_s: Float32[Array, '*chains p']) -> Float32[Array, '']:
+        """Effective number of predictors used for splitting across all chains.
+
+        Perplexity (exponential of the Shannon entropy) of the split-variable
+        distribution ``s = softmax(log_s)`` pooled (averaged) over chains. It is
+        1 when all chains concentrate on a single shared predictor and ``p`` when
+        the pooled distribution is uniform; in general a pooled distribution
+        spread evenly over ``k`` predictors gives ``k``. Chains are pooled before
+        taking the entropy because predictions average over all chains, so a
+        predictor used by any chain counts as used.
+        """
+        *_, p = log_s.shape
+        # normalize each chain
+        log_prob = log_s - logsumexp(log_s, axis=-1, keepdims=True)
+        log_pool = logmeanexp(log_prob.reshape(-1, p), axis=0)  # mix over chains
+        prob = jnp.exp(log_pool)
+        # the where avoids the 0 * -inf = nan term where a probability is 0, the
+        # same guard `jax.scipy.special.entr` uses, but reusing the log we have
+        entropy = -jnp.sum(prob * jnp.where(prob, log_pool, 1.0))
+        return jnp.exp(entropy)
+
+
 def make_print_callback(
     state: State,
     *,
     dot_every: int | Integer[Array, ''] | None = 1,
     report_every: int | Integer[Array, ''] | None = 100,
+    average: bool = True,
 ) -> dict[str, Any]:
     """
     Prepare a progress-printing callback for `run_mcmc`.
@@ -67,6 +206,10 @@ def make_print_callback(
     report_every
         A one line report is printed every `report_every` MCMC iterations,
         `None` to disable.
+    average
+        If `True`, the reported statistics are averaged over the iterations
+        since the previous report; if `False`, they reflect the current
+        iteration only. Ignored when `report_every` is `None`.
 
     Returns
     -------
@@ -80,11 +223,17 @@ def make_print_callback(
     def as_replicated_array_or_none(val: ArrayLike | None) -> None | Array:
         return None if val is None else _replicate(jnp.asarray(val), state.config.mesh)
 
+    accumulator = tree.map(
+        partial(_replicate, mesh=state.config.mesh),
+        StatsAccumulator.initial(state, enabled=average and report_every is not None),
+    )
+
     return dict(
         callback=print_callback,
         callback_state=PrintCallbackState(
             as_replicated_array_or_none(dot_every),
             as_replicated_array_or_none(report_every),
+            accumulator,
         ),
     )
 
@@ -99,6 +248,9 @@ class PrintCallbackState(Module):
     """A one line report is printed every `report_every` MCMC iterations,
     `None` to disable."""
 
+    accumulator: StatsAccumulator
+    """Running average of the reported statistics, inert unless averaging."""
+
 
 def print_callback(
     *,
@@ -110,11 +262,13 @@ def print_callback(
     n_skip: Int32[Array, ''],
     callback_state: PrintCallbackState,
     **_: Any,
-) -> None:
+) -> tuple[State, PrintCallbackState]:
     """Print a dot and/or a report periodically during the MCMC."""
     report_every = callback_state.report_every
     dot_every = callback_state.dot_every
     it = i_total + 1
+
+    accumulator = callback_state.accumulator.update(state)
 
     def get_cond(every: Int32[Array, ''] | None) -> bool | Bool[Array, '']:
         return False if every is None else it % every == 0
@@ -131,12 +285,12 @@ def print_callback(
             print_newline = it % report_every > it % dot_every
         debug.callback(
             _print_report,
+            accumulator.report(state),
             print_dot=dot_cond,
             print_newline=print_newline,
             burnin=burnin,
             it=it,
             n_iters=n_burn + n_save * n_skip,
-            **_forest_stats(state),
         )
 
     def just_dot_branch() -> None:
@@ -158,12 +312,16 @@ def print_callback(
         lambda: lax.cond(dot_cond, just_dot_branch, lambda: None),
     )
 
+    accumulator = accumulator.reset_if(report_cond)
+    return state, replace(callback_state, accumulator=accumulator)
+
 
 def make_tqdm_callback(
     state: State,
     *,
     update_every: int = 1,
     report_every: int | None = 100,
+    average: bool = True,
     **tqdm_kwargs: Any,
 ) -> dict[str, Any]:
     """
@@ -183,6 +341,10 @@ def make_tqdm_callback(
     report_every
         The acceptance statistics shown next to the bar are refreshed every
         `report_every` MCMC iterations, `None` to omit them.
+    average
+        If `True`, the statistics shown are averaged over the iterations since
+        the previous refresh; if `False`, they reflect the current iteration
+        only. Ignored when `report_every` is `None`.
     **tqdm_kwargs
         Additional keyword arguments forwarded to the `tqdm.tqdm` constructor,
         e.g., ``desc``, ``file``, or ``disable``.
@@ -216,6 +378,12 @@ def make_tqdm_callback(
             report_every=None
             if report_every is None
             else as_replicated_array(jnp.int32(report_every)),
+            accumulator=tree.map(
+                partial(_replicate, mesh=state.config.mesh),
+                StatsAccumulator.initial(
+                    state, enabled=average and report_every is not None
+                ),
+            ),
         ),
     )
 
@@ -233,6 +401,9 @@ class TqdmCallbackState(Module):
     """The acceptance statistics are refreshed every `report_every` MCMC
     iterations, `None` to omit them."""
 
+    accumulator: StatsAccumulator
+    """Running average of the reported statistics, inert unless averaging."""
+
 
 def tqdm_callback(
     *,
@@ -243,12 +414,14 @@ def tqdm_callback(
     n_skip: Int32[Array, ''],
     callback_state: TqdmCallbackState,
     **_: Any,
-) -> None:
+) -> tuple[State, TqdmCallbackState]:
     """Advance a `tqdm` progress bar during the MCMC."""
     it = i_total + 1
     n_iters = n_burn + n_save * n_skip
     bar_id = callback_state.bar_id
     last = it == n_iters
+
+    accumulator = callback_state.accumulator.update(state)
 
     # The callbacks are unordered: `ordered=True` is unsupported with more than
     # one device, and we need this to work with chains sharded across devices.
@@ -258,17 +431,21 @@ def tqdm_callback(
     # bar is advanced
     report_every = callback_state.report_every
     if report_every is not None:
+        report_cond = (it % report_every == 0) | last
 
         def report_branch() -> None:
-            debug.callback(_tqdm_report, bar_id, n_iters, **_forest_stats(state))
+            debug.callback(_tqdm_report, accumulator.report(state), bar_id, n_iters)
 
-        lax.cond((it % report_every == 0) | last, report_branch, lambda: None)
+        lax.cond(report_cond, report_branch, lambda: None)
+        accumulator = accumulator.reset_if(report_cond)
 
     lax.cond(
         (it % callback_state.update_every == 0) | last,
         lambda: debug.callback(_tqdm_advance, bar_id, it, n_iters),
         lambda: None,
     )
+
+    return state, replace(callback_state, accumulator=accumulator)
 
 
 T = TypeVar('T')
@@ -301,74 +478,17 @@ def _convert_jax_arrays_in_args(func: Callable[..., T]) -> Callable[..., T]:
     return new_func
 
 
-def _effective_predictors(log_s: Float32[Array, '*chains p']) -> Float32[Array, '']:
-    """Effective number of predictors used for splitting across all chains.
-
-    Perplexity (exponential of the Shannon entropy) of the split-variable
-    distribution ``s = softmax(log_s)`` pooled (averaged) over chains. It is 1
-    when all chains concentrate on a single shared predictor and ``p`` when the
-    pooled distribution is uniform; in general a pooled distribution spread
-    evenly over ``k`` predictors gives ``k``. Chains are pooled before taking the
-    entropy because predictions average over all chains, so a predictor used by
-    any chain counts as used.
-    """
-    *_, p = log_s.shape
-    log_prob = log_s - logsumexp(log_s, axis=-1, keepdims=True)  # normalize each chain
-    log_pool = logmeanexp(log_prob.reshape(-1, p), axis=0)  # mix over chains
-    prob = jnp.exp(log_pool)
-    # the where avoids the 0 * -inf = nan term where a probability is 0, the same
-    # guard `jax.scipy.special.entr` uses, but reusing the log we already have
-    entropy = -jnp.sum(prob * jnp.where(prob, log_pool, 1.0))
-    return jnp.exp(entropy)
-
-
-def _forest_stats(state: State) -> dict[str, Float32[Array, ''] | int | None]:
-    """Cross-chain proposal/acceptance/leaves statistics shown during the MCMC."""
-    chain_axis = chain_vmap_axes(state.forest).split_tree
-    num_trees_axis = chainful_axis(0, chain_axis)  # (num_trees, hts)
-    split_tree = chain_to_axis(state.forest.split_tree, chain_axis)
-    prop_total = state.forest.split_tree.shape[num_trees_axis]
-
-    log_s = state.forest.log_s
-    if log_s is None:
-        peff = None
-        p = None
-    else:
-        log_s = chain_to_axis(log_s, chain_vmap_axes(state.forest).log_s)
-        *_, p = log_s.shape
-        peff = _effective_predictors(log_s)
-
-    return dict(
-        num_chains=state.num_chains(),
-        grow_prop=state.forest.grow_prop_count.mean() / prop_total,
-        move_acc=(
-            state.forest.grow_acc_count.mean() + state.forest.prune_acc_count.mean()
-        )
-        / prop_total,
-        mean_leaves=forest_mean_leaves(split_tree),
-        max_leaves=split_tree.shape[-1],
-        peff=peff,
-        p=p,
-    )
-
-
 @_convert_jax_arrays_in_args
 # convert all jax arrays in arguments because operations on them could lead to
 # deadlock with the main thread
 def _print_report(
+    report: StatsReport,
     *,
     print_dot: bool,
     print_newline: bool,
     burnin: bool,
     it: int,
     n_iters: int,
-    num_chains: int | None,
-    grow_prop: float,
-    move_acc: float,
-    mean_leaves: float,
-    max_leaves: int,
-    peff: float | None,
-    p: int | None,
 ) -> None:
     """Print the report for `print_callback`."""
     # determine prefix
@@ -379,26 +499,31 @@ def _print_report(
     else:
         prefix = ''
 
-    # determine suffix in parentheses
+    # determine suffix in parentheses: what the statistics are averaged over
+    avg_over = []
+    if report.num_chains is not None:
+        avg_over.append(f'{report.num_chains} chains')
+    if report.n_samples is not None:
+        avg_over.append(f'{report.n_samples} samples')
     msgs = []
-    if num_chains is not None:
-        msgs.append(f'avg. {num_chains} chains')
+    if avg_over:
+        msgs.append('avg. ' + ' x '.join(avg_over))
     if burnin:
         msgs.append('burnin')
     suffix = f' ({", ".join(msgs)})' if msgs else ''
 
     # variable-selection concentration, only shown when it is enabled
-    if peff is None:
+    if report.peff is None:
         var_msg = ''
     else:
-        var_msg = f'var: {peff:.1f}/{p}, '
+        var_msg = f'var: {report.peff:.1f}/{report.p}, '
 
     print(  # noqa: T201, see print_callback for why not logging
         f'{prefix}Iteration {it}/{n_iters}, '
-        f'grow prob: {grow_prop:.0%}, '
-        f'move acc: {move_acc:.0%}, '
+        f'grow prob: {report.grow_prop:.0%}, '
+        f'move acc: {report.move_acc:.0%}, '
         f'{var_msg}'
-        f'leaves: {mean_leaves:.1f}/{max_leaves}{suffix}'
+        f'leaves: {report.mean_leaves:.1f}/{report.max_leaves}{suffix}'
     )
 
 
@@ -464,18 +589,7 @@ def _tqdm_advance(bar_id: int, it: int, n_iters: int) -> None:
 
 @_convert_jax_arrays_in_args
 # convert all jax arrays in arguments, see _print_report for why
-def _tqdm_report(
-    bar_id: int,
-    n_iters: int,
-    *,
-    num_chains: int | None,
-    move_acc: float,
-    mean_leaves: float,
-    max_leaves: int,
-    peff: float | None = None,
-    p: int | None = None,
-    **_: Any,
-) -> None:
+def _tqdm_report(report: StatsReport, bar_id: int, n_iters: int) -> None:
     """Set the bar description and acceptance-statistics postfix."""
     bar = _get_or_create_bar(bar_id, n_iters)
     if bar is None:
@@ -483,12 +597,14 @@ def _tqdm_report(
     # set_description_str (not set_description) to avoid tqdm's ': ' suffix; the
     # trailing space separates the label from the bar
     bar.set_description_str('train ', refresh=False)
-    # keep this terse so the bar stays narrow, e.g. '4ch acc 25% leaves 3.4/32'
+    # keep this terse so the bar stays narrow, e.g. '4ch 100sa acc 25% leaves 3.4/32'
     msgs = []
-    if num_chains is not None:
-        msgs.append(f'{num_chains}ch')
-    msgs.append(f'acc {move_acc:.0%}')
-    if peff is not None:
-        msgs.append(f'var {peff:.1f}/{p}')
-    msgs.append(f'leaves {mean_leaves:.1f}/{max_leaves}')
+    if report.num_chains is not None:
+        msgs.append(f'{report.num_chains}ch')
+    if report.n_samples is not None:
+        msgs.append(f'{report.n_samples}sa')
+    msgs.append(f'acc {report.move_acc:.0%}')
+    if report.peff is not None:
+        msgs.append(f'var {report.peff:.1f}/{report.p}')
+    msgs.append(f'leaves {report.mean_leaves:.1f}/{report.max_leaves}')
     bar.set_postfix_str(' '.join(msgs))

--- a/src/bartz/mcmcloop/_callback.py
+++ b/src/bartz/mcmcloop/_callback.py
@@ -34,7 +34,6 @@ import numpy
 from equinox import Module, field
 from jax import debug, eval_shape, lax, tree
 from jax import numpy as jnp
-from jax.nn import logmeanexp
 from jax.scipy.special import logsumexp
 from jaxtyping import Array, ArrayLike, Bool, Float32, Int32, Integer, PyTree
 from tqdm.auto import tqdm
@@ -175,7 +174,10 @@ class StatsAccumulator(Module):
         *_, p = log_s.shape
         # normalize each chain
         log_prob = log_s - logsumexp(log_s, axis=-1, keepdims=True)
-        log_pool = logmeanexp(log_prob.reshape(-1, p), axis=0)  # mix over chains
+        per_chain = log_prob.reshape(-1, p)
+        num_chains, _ = per_chain.shape
+        # mix over chains, i.e., logmeanexp over the chain axis
+        log_pool = logsumexp(per_chain, axis=0) - jnp.log(num_chains)
         prob = jnp.exp(log_pool)
         # the where avoids the 0 * -inf = nan term where a probability is 0, the
         # same guard `jax.scipy.special.entr` uses, but reusing the log we have

--- a/src/bartz/mcmcloop/_callback.py
+++ b/src/bartz/mcmcloop/_callback.py
@@ -176,7 +176,8 @@ class StatsAccumulator(Module):
         log_prob = log_s - logsumexp(log_s, axis=-1, keepdims=True)
         per_chain = log_prob.reshape(-1, p)
         num_chains, _ = per_chain.shape
-        # mix over chains, i.e., logmeanexp over the chain axis
+        # mix over chains. WORKAROUND(jax<0.7.1): once we bump jax to v0.7.1
+        # this is `jax.nn.logmeanexp(per_chain, axis=0)`
         log_pool = logsumexp(per_chain, axis=0) - jnp.log(num_chains)
         prob = jnp.exp(log_pool)
         # the where avoids the 0 * -inf = nan term where a probability is 0, the

--- a/src/bartz/mcmcloop/_callback.py
+++ b/src/bartz/mcmcloop/_callback.py
@@ -34,6 +34,8 @@ import numpy
 from equinox import Module
 from jax import debug, lax, tree
 from jax import numpy as jnp
+from jax.nn import logmeanexp
+from jax.scipy.special import logsumexp
 from jaxtyping import Array, ArrayLike, Bool, Float32, Int32, Integer, PyTree
 from tqdm.auto import tqdm
 
@@ -299,12 +301,43 @@ def _convert_jax_arrays_in_args(func: Callable[..., T]) -> Callable[..., T]:
     return new_func
 
 
+def _effective_predictors(log_s: Float32[Array, '*chains p']) -> Float32[Array, '']:
+    """Effective number of predictors used for splitting across all chains.
+
+    Perplexity (exponential of the Shannon entropy) of the split-variable
+    distribution ``s = softmax(log_s)`` pooled (averaged) over chains. It is 1
+    when all chains concentrate on a single shared predictor and ``p`` when the
+    pooled distribution is uniform; in general a pooled distribution spread
+    evenly over ``k`` predictors gives ``k``. Chains are pooled before taking the
+    entropy because predictions average over all chains, so a predictor used by
+    any chain counts as used.
+    """
+    *_, p = log_s.shape
+    log_prob = log_s - logsumexp(log_s, axis=-1, keepdims=True)  # normalize each chain
+    log_pool = logmeanexp(log_prob.reshape(-1, p), axis=0)  # mix over chains
+    prob = jnp.exp(log_pool)
+    # the where avoids the 0 * -inf = nan term where a probability is 0, the same
+    # guard `jax.scipy.special.entr` uses, but reusing the log we already have
+    entropy = -jnp.sum(prob * jnp.where(prob, log_pool, 1.0))
+    return jnp.exp(entropy)
+
+
 def _forest_stats(state: State) -> dict[str, Float32[Array, ''] | int | None]:
     """Cross-chain proposal/acceptance/leaves statistics shown during the MCMC."""
     chain_axis = chain_vmap_axes(state.forest).split_tree
     num_trees_axis = chainful_axis(0, chain_axis)  # (num_trees, hts)
     split_tree = chain_to_axis(state.forest.split_tree, chain_axis)
     prop_total = state.forest.split_tree.shape[num_trees_axis]
+
+    log_s = state.forest.log_s
+    if log_s is None:
+        peff = None
+        p = None
+    else:
+        log_s = chain_to_axis(log_s, chain_vmap_axes(state.forest).log_s)
+        *_, p = log_s.shape
+        peff = _effective_predictors(log_s)
+
     return dict(
         num_chains=state.num_chains(),
         grow_prop=state.forest.grow_prop_count.mean() / prop_total,
@@ -314,6 +347,8 @@ def _forest_stats(state: State) -> dict[str, Float32[Array, ''] | int | None]:
         / prop_total,
         mean_leaves=forest_mean_leaves(split_tree),
         max_leaves=split_tree.shape[-1],
+        peff=peff,
+        p=p,
     )
 
 
@@ -332,6 +367,8 @@ def _print_report(
     move_acc: float,
     mean_leaves: float,
     max_leaves: int,
+    peff: float | None,
+    p: int | None,
 ) -> None:
     """Print the report for `print_callback`."""
     # determine prefix
@@ -350,10 +387,17 @@ def _print_report(
         msgs.append('burnin')
     suffix = f' ({", ".join(msgs)})' if msgs else ''
 
+    # variable-selection concentration, only shown when it is enabled
+    if peff is None:
+        var_msg = ''
+    else:
+        var_msg = f'var: {peff:.1f}/{p}, '
+
     print(  # noqa: T201, see print_callback for why not logging
         f'{prefix}Iteration {it}/{n_iters}, '
         f'grow prob: {grow_prop:.0%}, '
         f'move acc: {move_acc:.0%}, '
+        f'{var_msg}'
         f'leaves: {mean_leaves:.1f}/{max_leaves}{suffix}'
     )
 
@@ -428,6 +472,8 @@ def _tqdm_report(
     move_acc: float,
     mean_leaves: float,
     max_leaves: int,
+    peff: float | None = None,
+    p: int | None = None,
     **_: Any,
 ) -> None:
     """Set the bar description and acceptance-statistics postfix."""
@@ -442,5 +488,7 @@ def _tqdm_report(
     if num_chains is not None:
         msgs.append(f'{num_chains}ch')
     msgs.append(f'acc {move_acc:.0%}')
+    if peff is not None:
+        msgs.append(f'var {peff:.1f}/{p}')
     msgs.append(f'leaves {mean_leaves:.1f}/{max_leaves}')
     bar.set_postfix_str(' '.join(msgs))

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -74,18 +74,20 @@ from bartz._jaxext import (
     get_device_count,
     is_key,
     jaxtyping_disabled,
+    minimal_unsigned_dtype,
     split,
 )
 from bartz.debug import TraceWithOffset, sample_prior
 from bartz.grove import (
     check_trace,
+    describe_error,
     forest_depth_distr,
     is_actual_leaf,
     tree_actual_depth,
     tree_depth,
     tree_depths,
 )
-from bartz.mcmcloop import compute_varcount, evaluate_trace
+from bartz.mcmcloop import CallbackState, compute_varcount, evaluate_trace
 from bartz.mcmcloop._callback import _TQDM_REGISTRY
 from bartz.mcmcloop._loop import _run_mcmc_inner_loop
 from bartz.mcmcstep import State
@@ -857,6 +859,54 @@ def test_tree_structure_changes(bkw: BartKW, subtests: SubTests) -> None:
         assert jnp.all(grow_acc <= grow_prop)
         assert jnp.all(prune_acc <= prune_prop)
         assert jnp.all(grow_prop + prune_prop <= num_trees)
+
+
+def test_check_trees_detects_corruption(bkw: BartKW) -> None:
+    """`_check_trees` flags trees corrupted mid-MCMC (guard against false negatives).
+
+    A callback injected through ``run_mcmc_kw`` rewrites every decision node to
+    split on an out-of-range variable index after each MCMC step. The corruption
+    is deliberately benign for the dynamics: JAX clips the out-of-bounds gather,
+    so each tree merely splits on the last predictor instead of the intended
+    one, the run stays finite (no NaNs/infs) and completes normally. But the
+    saved trees violate the ``check_var_in_bounds`` invariant, which
+    `_check_trees` (used by the `Bart` test wrapper's ``__init__``) must catch.
+    """
+
+    def corrupt(
+        *, state: State, callback_state: CallbackState, **_: Any
+    ) -> tuple[State, CallbackState]:
+        forest = state.forest
+        # max_split.size is the first out-of-range variable index; the var dtype
+        # is sized for indices up to max_split.size - 1, so guard that this one
+        # extra value still fits (it does whenever the count is not exactly at a
+        # dtype boundary, which holds for every variant)
+        oob_value = forest.max_split.size
+        assert minimal_unsigned_dtype(oob_value) == forest.var_tree.dtype
+        oob_var = jnp.array(oob_value, forest.var_tree.dtype)
+        var_tree = jnp.where(forest.split_tree != 0, oob_var, forest.var_tree)
+        forest = replace(forest, var_tree=var_tree)
+        return replace(state, forest=forest), callback_state
+
+    kw = dict(bkw.kw, run_mcmc_kw=dict(callback=corrupt))
+
+    # build via the unwrapped class so the (finite) run completes without the
+    # wrapper's automatic check aborting it, then inspect the corrupted trace
+    bart = OriginalBart(**kw)
+
+    bad = bart._check_trees()
+    # every decision node now points at an out-of-range variable; trees that
+    # happen to be a bare root leaf carry no decision node and stay valid
+    assert jnp.any(bad), 'corruption went undetected (false negative)'
+    for code in jnp.unique(bad[bad != 0]).tolist():
+        assert describe_error(code) == ['check_var_in_bounds']
+
+    # end-to-end: `Bart` (the wrapper used throughout the tests) runs
+    # `_check_trees(error=True)` in `__init__`, so the corrupted run must abort
+    # construction. Testing the real wrapper, not just `_check_trees`, also
+    # catches a wrapper that silently fails to invoke or propagate the check.
+    with pytest.raises(RuntimeError, match='invalid trees'):
+        Bart(**dict(kw, seed=random.clone(kw['seed'])))
 
 
 def test_missing_ignored(bkw: BartKW, keys: split) -> None:

--- a/tests/test_mcmcloop.py
+++ b/tests/test_mcmcloop.py
@@ -193,33 +193,22 @@ class TestRunMcmc:
         check_trace(burnin_trace)
         check_trace(main_trace)
 
-    def test_tqdm_callback(self, keys: split, initial_state: State) -> None:
-        """Check the tqdm progress bar runs to completion and is cleaned up."""
-        buf = io.StringIO()
-        kw = make_tqdm_callback(initial_state, report_every=2, file=buf, mininterval=0)
-        bar_id = kw['callback_state'].bar_id.item()
-        state = tree.map(jnp.copy, initial_state)  # donated
-        with debug_key_reuse(False):
-            # block so the (unordered, async) progress callbacks have all fired
-            block_until_ready(run_mcmc(keys.pop(), state, 4, n_burn=2, **kw))
+    @pytest.mark.parametrize('average', [True, False])
+    def test_tqdm_callback(
+        self, keys: split, initial_state: State, average: bool
+    ) -> None:
+        """Check the tqdm progress bar runs to completion and is cleaned up.
 
-        out = buf.getvalue()
-        assert '100%' in out  # the bar reached the end
-        assert '6/6' in out  # n_burn + n_save * n_skip iterations
-        assert bar_id not in _TQDM_REGISTRY  # the bar was closed and removed
-
-    def test_tqdm_callback_no_average(self, keys: split) -> None:
-        """Check the tqdm callback also runs with `average=False`.
-
-        Exercises the stats-accumulator path where the running sums are absent
-        (`average=False`), so each report shows the latest iteration only.
+        Parametrized over ``average`` to also exercise the stats-accumulator
+        path where the running sums are absent (``average=False``), so each
+        report shows the latest iteration only.
         """
-        state = simple_init(10, 100, 20)
         buf = io.StringIO()
         kw = make_tqdm_callback(
-            state, report_every=2, file=buf, mininterval=0, average=False
+            initial_state, report_every=2, file=buf, mininterval=0, average=average
         )
         bar_id = kw['callback_state'].bar_id.item()
+        state = tree.map(jnp.copy, initial_state)  # donated
         with debug_key_reuse(False):
             # block so the (unordered, async) progress callbacks have all fired
             block_until_ready(run_mcmc(keys.pop(), state, 4, n_burn=2, **kw))

--- a/tests/test_mcmcloop.py
+++ b/tests/test_mcmcloop.py
@@ -208,6 +208,27 @@ class TestRunMcmc:
         assert '6/6' in out  # n_burn + n_save * n_skip iterations
         assert bar_id not in _TQDM_REGISTRY  # the bar was closed and removed
 
+    def test_tqdm_callback_no_average(self, keys: split) -> None:
+        """Check the tqdm callback also runs with `average=False`.
+
+        Exercises the stats-accumulator path where the running sums are absent
+        (`average=False`), so each report shows the latest iteration only.
+        """
+        state = simple_init(10, 100, 20)
+        buf = io.StringIO()
+        kw = make_tqdm_callback(
+            state, report_every=2, file=buf, mininterval=0, average=False
+        )
+        bar_id = kw['callback_state'].bar_id.item()
+        with debug_key_reuse(False):
+            # block so the (unordered, async) progress callbacks have all fired
+            block_until_ready(run_mcmc(keys.pop(), state, 4, n_burn=2, **kw))
+
+        out = buf.getvalue()
+        assert '100%' in out  # the bar reached the end
+        assert '6/6' in out  # n_burn + n_save * n_skip iterations
+        assert bar_id not in _TQDM_REGISTRY  # the bar was closed and removed
+
     def test_tqdm_callback_cleans_up_interrupted_bar(self) -> None:
         """A new tqdm callback closes a bar left open by an interrupted run."""
         state = simple_init(10, 100, 20)


### PR DESCRIPTION
## Summary

Improves the MCMC progress callbacks (`mcmcloop/_callback.py`) with richer, more stable diagnostics:

- **Moving-average reporting** — progress callbacks now report statistics averaged over the iterations since the previous report rather than a single-iteration snapshot, so acceptance rates, leaf counts and effective predictors read as stable windowed averages. A new `StatsAccumulator` (carried in both callback states) sums per-iteration stats and resets at each report; toggled by the new `average` argument (default on). When averaging, the report annotates the window size, e.g. `(avg. 4 chains x 100 samples)` / `4ch 100sa`. Stats are passed to report callbacks as a `StatsReport` pytree module.
- **Effective number of predictors** — adds a `var: peff/p` field to the print and tqdm callbacks, shown only when variable selection is enabled. `peff` is the perplexity (exp of the Shannon entropy) of the split-variable distribution pooled across chains: 1 when concentrated on a single predictor, `p` when uniform. Chains are pooled before taking entropy because predictions average over all chains.
- **Test hardening** — adds a test that injects a callback rewriting every decision node to split on an out-of-range variable index after each MCMC step, verifying `_check_trees` flags corrupt trees with `check_var_in_bounds` and that the `Bart` test wrapper raises end-to-end.

New public exports: `StatsAccumulator`, `StatsReport`.

## Test plan

- [ ] CI green (lint + full test suite)

---

*This PR was prepared by Claude (Claude Code) on behalf of @Gattocrucco.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
