### PR TITLE
Make the test suite pass on small GPUs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,12 +157,19 @@ SELECT = $(if $(GROUP),$(GROUP_$(GROUP)))
 # (xdist off) because the small runners OOM under parallel test execution.
 NPROC ?= 2
 
+# On GPU, parallel workers overlap compilation (which dominates the run time),
+# but the processes share the GPU memory and OOM on small cards, so fall back
+# to a single worker when the GPU has less total memory than this (MiB).
+GPU_MIN_MEM = 15000
+GPU_MEM = $(shell nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | head -n1)
+GPU_NPROC = $(shell [ "$(GPU_MEM)" -ge $(GPU_MIN_MEM) ] 2>/dev/null && echo $(NPROC) || echo 1)
+
 TESTS_VARS = COVERAGE_FILE=.coverage.$@$(if $(GROUP),-$(GROUP))
 TESTS_COMMAND = python -m pytest --cov --cov-context=test --dist=worksteal --durations=1000
 TESTS_CPU_VARS = $(TESTS_VARS) JAX_PLATFORMS=cpu
 TESTS_CPU_COMMAND = $(TESTS_COMMAND) --platform=cpu --numprocesses=$(NPROC) $(SELECT)
 TESTS_GPU_VARS = $(TESTS_VARS) XLA_PYTHON_CLIENT_PREALLOCATE=false
-TESTS_GPU_COMMAND = $(TESTS_COMMAND) --platform=gpu --numprocesses=$(NPROC) $(SELECT)
+TESTS_GPU_COMMAND = $(TESTS_COMMAND) --platform=gpu --numprocesses=$(GPU_NPROC) $(SELECT)
 
 .PHONY: tests
 tests:

--- a/Makefile
+++ b/Makefile
@@ -158,11 +158,16 @@ SELECT = $(if $(GROUP),$(GROUP_$(GROUP)))
 NPROC ?= 2
 
 # On GPU, parallel workers overlap compilation (which dominates the run time),
-# but the processes share the GPU memory and OOM on small cards, so fall back
-# to a single worker when the GPU has less total memory than this (MiB).
+# but the processes share the GPU memory and OOM on small cards, so turn off
+# xdist when the GPU has less total memory than this (MiB). An explicit NPROC
+# (command line or environment) takes precedence over the detection.
 GPU_MIN_MEM = 15000
 GPU_MEM = $(shell nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | head -n1)
-GPU_NPROC = $(shell [ "$(GPU_MEM)" -ge $(GPU_MIN_MEM) ] 2>/dev/null && echo $(NPROC) || echo 1)
+ifeq ($(origin NPROC),file)
+GPU_NPROC = $(shell [ "$(GPU_MEM)" -ge $(GPU_MIN_MEM) ] 2>/dev/null && echo $(NPROC) || echo 0)
+else
+GPU_NPROC = $(NPROC)
+endif
 
 TESTS_VARS = COVERAGE_FILE=.coverage.$@$(if $(GROUP),-$(GROUP))
 TESTS_COMMAND = python -m pytest --cov --cov-context=test --dist=worksteal --durations=1000

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -931,8 +931,18 @@ def test_zero_or_one_datapoint(kw: dict[str, Any], num_datapoints: int) -> None:
     )
 
     # check the likelihood ratio is always 1
-    assert_array_equal(bart._burnin_trace.log_likelihood, 0.0, strict=False)
-    assert_array_equal(bart._main_trace.log_likelihood, 0.0, strict=False)
+    assert_close_matrices(
+        bart._burnin_trace.log_likelihood,
+        jnp.zeros_like(bart._burnin_trace.log_likelihood),
+        atol=1e-5,
+        reduce_rank=True,
+    )
+    assert_close_matrices(
+        bart._main_trace.log_likelihood,
+        jnp.zeros_like(bart._main_trace.log_likelihood),
+        atol=1e-5,
+        reduce_rank=True,
+    )
 
 
 def test_two_datapoints(kw: dict[str, Any]) -> None:
@@ -1118,8 +1128,18 @@ def run_bart_like_prior(
     bart = mc_gbart(**kw)
 
     with subtests.test('likelihood ratio = 1'):
-        assert_array_equal(bart._burnin_trace.log_likelihood, 0.0, strict=False)
-        assert_array_equal(bart._main_trace.log_likelihood, 0.0, strict=False)
+        assert_close_matrices(
+            bart._burnin_trace.log_likelihood,
+            jnp.zeros_like(bart._burnin_trace.log_likelihood),
+            atol=1e-5,
+            reduce_rank=True,
+        )
+        assert_close_matrices(
+            bart._main_trace.log_likelihood,
+            jnp.zeros_like(bart._main_trace.log_likelihood),
+            atol=1e-5,
+            reduce_rank=True,
+        )
 
     return bart
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -95,6 +95,7 @@ from bartz.mcmcstep._axes import chain_to_axis, chain_vmap_axes
 from bartz.prepcovars import GivenSplitsBinner, RangeEvenBinner, UniqueQuantileBinner
 from tests.test_mcmcstep import check_sharding, get_normal_spec, normalize_spec
 from tests.util import (
+    assert_allclose,
     assert_array_equal,
     assert_close_matrices,
     assert_different_matrices,
@@ -1517,19 +1518,16 @@ def test_zero_or_one_datapoint(bkw: BartKW, num_datapoints: int) -> None:
         expected_cov_inv = jnp.eye(leaf_prior_cov_inv.shape[0]) * expected_cov_inv
     assert_close_matrices(leaf_prior_cov_inv, expected_cov_inv, rtol=1e-6)
 
-    # with 1 datapoint in the multivariate case, log_likelihood is not exactly 0
-    # because matrix inversion adds an epsilon to handle ill-conditioned matrices
-    atol = 0.0 if num_datapoints == 0 else 1e-4
     assert_close_matrices(
         bart._burnin_trace.log_likelihood,
         jnp.zeros_like(bart._burnin_trace.log_likelihood),
-        atol=atol,
+        atol=1e-4,
         reduce_rank=True,
     )
     assert_close_matrices(
         bart._main_trace.log_likelihood,
         jnp.zeros_like(bart._main_trace.log_likelihood),
-        atol=atol,
+        atol=1e-4,
         reduce_rank=True,
     )
 
@@ -2558,6 +2556,7 @@ def test_uv_mv_k1_equivalence(bkw: BartKW) -> None:
     assert_close_matrices(
         chain_to_axis(state_uv.resid, uv_axes.resid),
         chain_to_axis(state_mv.resid, mv_axes.resid).squeeze(-2),
+        rtol=1e-7,
     )
     assert_close_matrices(
         chain_to_axis(state_uv.error_cov_inv, uv_axes.error_cov_inv),
@@ -2565,18 +2564,19 @@ def test_uv_mv_k1_equivalence(bkw: BartKW) -> None:
         rtol=1e-6,
     )
 
-    # Prior parameters
-    assert_array_equal(bart_uv.offset, bart_mv.offset.squeeze(0))
-    assert_array_equal(
+    # Prior parameters (scalar floats, only equal up to GPU rounding)
+    assert_allclose(bart_uv.offset, bart_mv.offset.squeeze(0), rtol=1e-6)
+    assert_allclose(
         state_uv.forest.leaf_prior_cov_inv,
         state_mv.forest.leaf_prior_cov_inv.reshape(()),
+        rtol=1e-6,
     )
     if outcome_type == 'continuous':
         assert_array_equal(state_uv.error_cov_df, state_mv.error_cov_df)
-        assert_array_equal(
-            state_uv.error_cov_scale, state_mv.error_cov_scale.reshape(())
+        assert_allclose(
+            state_uv.error_cov_scale, state_mv.error_cov_scale.reshape(()), rtol=1e-6
         )
-        assert_array_equal(bart_uv.sigest, bart_mv.sigest.squeeze(0))
+        assert_allclose(bart_uv.sigest, bart_mv.sigest.squeeze(0), rtol=1e-6)
 
     # Forest structure
     uv_forest_axes = chain_vmap_axes(state_uv.forest)

--- a/tests/test_mcmcloop.py
+++ b/tests/test_mcmcloop.py
@@ -118,6 +118,20 @@ def cat_traces(
     return tree.map(cat, trace_a, trace_b, sample_axes)
 
 
+def assert_trace_close(actual: Array, desired: Array) -> None:
+    """Compare state/trace leaves, tolerating GPU floating-point rounding.
+
+    Integer and boolean leaves must match exactly; floating-point leaves are
+    compared up to a relative tolerance, because the order of floating-point
+    reductions on GPU is not bit-reproducible across different iteration
+    chunkings.
+    """
+    if jnp.issubdtype(actual.dtype, jnp.floating):
+        assert_close_matrices(actual, desired, rtol=1e-4, reduce_rank=True)
+    else:
+        assert_array_equal(actual, desired)
+
+
 class TestRunMcmc:
     """Test `mcmcloop.run_mcmc`."""
 
@@ -313,8 +327,8 @@ class TestRunMcmc:
             )
             final_split, _, main_b = run_mcmc(key, mid, 3, n_burn=0, n_skip=1)
 
-        tree.map(assert_array_equal, final_single, final_split)
-        tree.map(assert_array_equal, main_single, cat_traces(main_a, main_b))
+        tree.map(assert_trace_close, final_single, final_split)
+        tree.map(assert_trace_close, main_single, cat_traces(main_a, main_b))
 
     def test_inner_loop_length_invariance(
         self, keys: split, initial_state: State
@@ -334,9 +348,9 @@ class TestRunMcmc:
                 inner_loop_length=1,
             )
 
-        tree.map(assert_array_equal, final_whole, final_chunked)
-        tree.map(assert_array_equal, main_whole, main_chunked)
-        tree.map(assert_array_equal, burnin_whole, burnin_chunked)
+        tree.map(assert_trace_close, final_whole, final_chunked)
+        tree.map(assert_trace_close, main_whole, main_chunked)
+        tree.map(assert_trace_close, burnin_whole, burnin_chunked)
 
 
 # shared test-point count, reused across cases to hit the jax compilation cache

--- a/tests/test_stochtree.py
+++ b/tests/test_stochtree.py
@@ -957,7 +957,7 @@ class TestPreprocessing:
     def test_end_to_end_numeric_matches_array(
         self, continuous_data: _Data, flavor: str, keys: split
     ) -> None:
-        """A numeric DataFrame produces bit-identical posteriors to the same array."""
+        """A numeric DataFrame produces the same posteriors as the equivalent array."""
         data = continuous_data
         X_arr = np.asarray(data.X_train)
         Xte_arr = np.asarray(data.X_test)
@@ -979,8 +979,8 @@ class TestPreprocessing:
         key = keys.pop()
         m_arr = self._sample(X_arr, data.y_train, X_test=Xte_arr, key=key)
         m_df = self._sample(df_train, data.y_train, X_test=df_test, key=key)
-        assert_close_matrices(m_arr.y_hat_train, m_df.y_hat_train)
-        assert_close_matrices(m_arr.y_hat_test, m_df.y_hat_test)
+        assert_close_matrices(m_arr.y_hat_train, m_df.y_hat_train, rtol=1e-5)
+        assert_close_matrices(m_arr.y_hat_test, m_df.y_hat_test, rtol=1e-5)
 
     @pytest.mark.parametrize('flavor', ['pandas', 'polars'])
     def test_end_to_end_one_hot_matches_manual(
@@ -1051,8 +1051,8 @@ class TestPreprocessing:
             key=key,
             general_params={'variable_weights': w_df},
         )
-        assert_close_matrices(m_manual.y_hat_train, m_df.y_hat_train)
-        assert_close_matrices(m_manual.y_hat_test, m_df.y_hat_test)
+        assert_close_matrices(m_manual.y_hat_train, m_df.y_hat_train, rtol=1e-5)
+        assert_close_matrices(m_manual.y_hat_test, m_df.y_hat_test, rtol=1e-5)
 
     @pytest.mark.parametrize('flavor', ['pandas', 'polars'])
     def test_end_to_end_default_weights_split_like_stochtree(
@@ -1107,8 +1107,8 @@ class TestPreprocessing:
             key=key,
             general_params={'variable_weights': w_split},
         )
-        assert_close_matrices(m_manual.y_hat_train, m_df.y_hat_train)
-        assert_close_matrices(m_manual.y_hat_test, m_df.y_hat_test)
+        assert_close_matrices(m_manual.y_hat_train, m_df.y_hat_train, rtol=1e-5)
+        assert_close_matrices(m_manual.y_hat_test, m_df.y_hat_test, rtol=1e-5)
 
     @pytest.mark.parametrize('flavor', ['pandas', 'polars'])
     def test_predict_with_array_after_dataframe_fit_raises(


### PR DESCRIPTION
Two fixes for running the test suite on GPU:

- **test: loosen exact GPU comparisons for float32** — several tests asserted bit-exact equality, which holds on CPU but not on GPU where float32 reduction order differs; loosened to GPU-appropriate tolerances.
- **build: use a single test worker on small GPUs** — parallel xdist workers share GPU memory and OOM on a 12 GiB card; the Makefile now picks the worker count from the memory reported by `nvidia-smi`.

This PR was authored by Claude (Opus 4.8) via Claude Code, routed through @Gattocrucco's account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)