### PR TITLE
ci: republish docs on release via dispatch

### DIFF
--- a/.github/actions/build-docs/action.yml
+++ b/.github/actions/build-docs/action.yml
@@ -1,0 +1,66 @@
+# bartz/.github/actions/build-docs/action.yml
+#
+# Copyright (c) 2026, The Bartz Contributors
+#
+# This file is part of bartz.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: Build documentation
+description: >-
+  Build the HTML docs (latest release + development) and benchmarks, and upload
+  them as the `docs` artifact. The repository must already be checked out with
+  full history (fetch-depth 0) so hatch-vcs and `docs-latest` see the tags.
+
+inputs:
+  uv-version:
+    description: Version of uv to install.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Ensure main branch exists (for asv publish)
+      shell: bash
+      run: |
+        git branch main origin/main || true
+        git branch --set-upstream-to=origin/main main || true
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        version: ${{ inputs.uv-version }}
+
+    - name: Generate benchmarks visualization
+      shell: bash
+      run: RPY2_CFFI_MODE=ABI make asv-publish
+
+    - name: Generate documentation
+      shell: bash
+      run: RPY2_CFFI_MODE=ABI make docs docs-latest
+
+    - name: Save documentation
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      with:
+        name: docs
+        path: |
+          _site/docs
+          _site/docs-dev
+          _site/benchmarks
+        if-no-files-found: error

--- a/.github/actions/deploy-site/action.yml
+++ b/.github/actions/deploy-site/action.yml
@@ -1,0 +1,86 @@
+# bartz/.github/actions/deploy-site/action.yml
+#
+# Copyright (c) 2026, The Bartz Contributors
+#
+# This file is part of bartz.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+name: Deploy site to GitHub Pages
+description: >-
+  Assemble the `docs` artifact plus the coverage report into `_site` and deploy
+  it to GitHub Pages. The calling job must set the `github-pages` environment and
+  `pages: write` / `id-token: write` permissions.
+
+inputs:
+  coverage-run-id:
+    description: >-
+      Run id to fetch the `covreport` artifact from. Empty means the artifact
+      lives in the current run; a value fetches it from another run (which needs
+      `actions: read` and a token).
+    required: false
+    default: ""
+  github-token:
+    description: Token used to fetch the coverage report from another run.
+    required: false
+    default: ""
+
+outputs:
+  page-url:
+    description: URL of the deployed site.
+    value: ${{ steps.deployment.outputs.page_url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Pages
+      uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+
+    - name: Get documentation and benchmarks
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: docs
+        path: _site
+
+    - name: Get coverage report
+      if: inputs.coverage-run-id == ''
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: covreport
+        path: _site/coverage
+
+    - name: Get coverage report from another run
+      if: inputs.coverage-run-id != ''
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: covreport
+        path: _site/coverage
+        run-id: ${{ inputs.coverage-run-id }}
+        github-token: ${{ inputs.github-token }}
+
+    - name: List files
+      shell: bash
+      run: ls -a _site
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,0 +1,138 @@
+# bartz/.github/workflows/release-docs.yml
+#
+# Copyright (c) 2026, The Bartz Contributors
+#
+# This file is part of bartz.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Republish the documentation for a release. A tag points at a commit already on
+# main, whose merge-push run (in tests.yml) already deployed the docs -- but with
+# the *previous* release as the latest tag, since the new tag did not exist yet.
+# We must rebuild and redeploy now that the tag exists. Deploying straight from
+# the tag push does not work: actions/deploy-pages dedupes by commit SHA and
+# silently keeps the earlier build live (actions/deploy-pages#383). A
+# workflow_dispatch deploy of the same SHA *does* swap the content, so the tag
+# push only re-triggers this workflow as a dispatch, which rebuilds the docs and
+# deploys them, reusing the merge-push run's coverage report.
+
+name: release-docs
+permissions:
+  contents: read
+
+on:
+  push:
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      coverage_run_id:
+        description: Run id to fetch the coverage report from.
+        type: string
+        required: true
+
+env:
+  UV_VERSION: "0.11.25"
+
+jobs:
+  redispatch:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify the tag commit is on main
+        run: |
+          git fetch origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main \
+            || { echo "::error::tag commit $GITHUB_SHA is not on main"; exit 1; }
+
+      - name: Find the merge-push run that built coverage for this commit
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          run_id=$(gh run list --repo "$GITHUB_REPOSITORY" \
+            --workflow=tests.yml --branch=main --event=push \
+            --json databaseId,headSha --limit 50 \
+            --jq "map(select(.headSha == \"$GITHUB_SHA\")) | .[0].databaseId")
+          if [ -z "$run_id" ]; then
+            echo "::error::no main push CI run found for $GITHUB_SHA"; exit 1
+          fi
+          echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for it to finish so its coverage artifact exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh run watch --repo "$GITHUB_REPOSITORY" "${{ steps.source.outputs.run_id }}" || true
+
+      - name: Re-trigger as a workflow_dispatch to deploy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run release-docs.yml --repo "$GITHUB_REPOSITORY" --ref main \
+            -f coverage_run_id="${{ steps.source.outputs.run_id }}"
+
+  docs:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0 # this fetches the full history
+
+      - name: Build documentation
+        uses: ./.github/actions/build-docs
+        with:
+          uv-version: ${{ env.UV_VERSION }}
+
+  deploy:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs: [docs]
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      actions: read
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page-url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Deploy site
+        id: deploy
+        uses: ./.github/actions/deploy-site
+        with:
+          coverage-run-id: ${{ inputs.coverage_run_id }}
+          github-token: ${{ github.token }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - v*
   workflow_dispatch:
   pull_request:
     branches:
@@ -144,34 +142,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ startsWith(github.ref, 'refs/tags/') && 'main' || '' }}
           fetch-depth: 0 # this fetches the full history
 
-      - name: Ensure main branch exists (for asv publish)
-        run: |
-          git branch main origin/main || true
-          git branch --set-upstream-to=origin/main main || true
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Build documentation
+        uses: ./.github/actions/build-docs
         with:
-          version: ${{ env.UV_VERSION }}
-
-      - name: Generate benchmarks visualization
-        run: RPY2_CFFI_MODE=ABI make asv-publish
-
-      - name: Generate documentation
-        run: RPY2_CFFI_MODE=ABI make docs docs-latest
-
-      - name: Save documentation
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: docs
-          path: |
-            _site/docs
-            _site/docs-dev
-            _site/benchmarks
-          if-no-files-found: error
+          uv-version: ${{ env.UV_VERSION }}
 
   covreport:
     runs-on: ubuntu-latest
@@ -257,7 +233,9 @@ jobs:
           fi
 
   deploy:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    # Publishes the docs for ordinary main pushes. Release republishing (so the
+    # stable docs pick up a freshly pushed tag) lives in release-docs.yml.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [docs, covreport]
 
@@ -268,56 +246,15 @@ jobs:
 
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deploy.outputs.page-url }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          fetch-depth: 0
 
-      - name: Verify tag commit is on main
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          git fetch origin main
-          git merge-base --is-ancestor HEAD origin/main \
-            || { echo "Tag commit is not on main branch"; exit 1; }
-
-      - name: Setup Pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
-
-      - name: Get documentation and benchmarks
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: docs
-          path: _site
-
-      - name: Get coverage report
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: covreport
-          path: _site/coverage
-
-      - name: List files
-        run: |
-          pwd
-          ls -a
-          ls -a _site
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
-        env:
-          # actions/deploy-pages derives the deployment's pages_build_version
-          # from $GITHUB_SHA, and GitHub Pages dedupes deployments by that value.
-          # A release tags an existing main commit, so the merge-to-main push and
-          # the tag push deploy the same SHA twice; Pages then short-circuits the
-          # second (correct, post-tag) build and keeps the stale pre-tag one live.
-          # Make the version unique per run so every deploy actually publishes.
-          GITHUB_SHA: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Deploy site
+        id: deploy
+        uses: ./.github/actions/deploy-site
 
   benchmarks:
     name: benchmarks-${{ matrix.id }}


### PR DESCRIPTION
The stable docs at the Pages site stayed at the previous release after tagging v0.11.0. Root cause: GitHub Pages dedupes `actions/deploy-pages` by commit SHA, so the tag-push deploy of an already-pushed merge commit is silently dropped and the pre-tag build stays live ([actions/deploy-pages#383](https://github.com/actions/deploy-pages/issues/383)). A `workflow_dispatch` deploy of the same SHA *does* swap the content.

Release republishing now lives in `release-docs.yml`: a tag push verifies the commit is on main and re-triggers the workflow as a `workflow_dispatch`, which rebuilds the docs (now that the tag exists, `docs-latest` resolves to it) and deploys them, reusing the merge run's coverage report rather than re-running the test matrix. `tests.yml` goes back to a plain CI with no release/tag gating that deploys on main pushes.

The shared docs-build and Pages-deploy steps move into two composite actions (`build-docs`, `deploy-site`) so both workflows reuse them without duplication.

Known follow-up: `UV_VERSION` is duplicated across the two workflows; left for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)