### PR TITLE
docs: update BART packages list

### DIFF
--- a/docs/pkglist.md
+++ b/docs/pkglist.md
@@ -26,6 +26,8 @@ SOFTWARE.
 
 # Other BART packages
 
+Some of the R-only BART packages are wrapped for Python in [rbartpackages](https://github.com/bartz-org/rbartpackages).
+
 - [stochtree](https://github.com/StochasticTree/stochtree) C++ library with R and Python interfaces
 - [bnptools](https://github.com/rsparapa/bnptools) Feature-rich R packages for BART and some variants
 - [vdorie](https://github.com/vdorie)'s repositories (dbarts, bartCause, stan4bart)

--- a/docs/pkglist.md
+++ b/docs/pkglist.md
@@ -35,8 +35,7 @@ SOFTWARE.
 - [skdeshpande91](https://github.com/skdeshpande91)'s repositories (flexBART, flexBCF, VCBART)
 - [JingyuHe](https://github.com/JingyuHe)'s repositories (XBART & related)
 - [BayesTree](https://cran.r-project.org/package=BayesTree) R package, original BART implementation
-- [OpenBT](https://bitbucket.org/mpratola/openbt) Heteroskedastic BART, rotate & perturb proposals, C++ library with R interface
-- [OpenBT](https://github.com/jcyannotty/OpenBT) fork of the above
+- [OpenBT](https://github.com/bandframework/OpenBT) Heteroskedastic BART, rotate & perturb proposals, C++ library with R and Python interfaces
 - [lsqfitgp](https://github.com/Gattocrucco/lsqfitgp) Infinite trees limit of BART
 - [mBART](https://github.com/remcc/mBART_shlib)
 - [SequentialBART](https://github.com/mjdaniels/SequentialBART)
@@ -63,3 +62,5 @@ SOFTWARE.
 - [missBART](https://github.com/yongchengoh/missBART) BART for missing outcome data
 - [mvbcf](https://github.com/Nathan-McJames/mvbcf) Multivariate BCF
 - [rBART](https://github.com/andrewcparnell/rBART) Slow version of BART in R
+- [BASTION](https://github.com/rayisaacalan/BASTION) Spanning tree partitions instead of axis-aligned splits, for spatial data on complex domains
+- [ztluostat](https://github.com/ztluostat)'s repositories (BAST, BAMDT)


### PR DESCRIPTION
Update the "Other BART packages" docs page: add BASTION (spanning tree partitions for spatial data on complex domains) and ztluostat's repositories (BAST, BAMDT), and replace the two OpenBT entries (Bitbucket original and jcyannotty fork) with the current home at bandframework/OpenBT. Also mention rbartpackages, which wraps some R-only BART packages for Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)