### PR TITLE
build: forbid jax 0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,8 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "equinox>=0.12.2",
-    # WORKAROUND(jax<0.10.3): jax 0.10.2 has a severe GPU scatter-add
-    # regression (high-contention scatter into a small array is up to ~2000x
-    # slower than 0.10.1), which hits the per-leaf reductions; exclude it.
-    "jax>=0.6.2,!=0.10.2",
+    # WORKAROUND(jax<0.12): see https://github.com/jax-ml/jax/issues/38806
+    "jax>=0.6.2,!=0.10.2,!=0.11.0",
     "jaxtyping>=0.3.2",
     "numpy>=2.2.6",
     "scipy>=1.15.3",
@@ -48,9 +46,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# WORKAROUND(jax<0.10.3): exclude jax 0.10.2, see the core jax dependency above
-cuda12 = ["jax[cuda12]>=0.6.2,!=0.10.2"]
-cuda13 = ["jax[cuda13]>=0.6.2,!=0.10.2"]
+# WORKAROUND(jax<0.12): see https://github.com/jax-ml/jax/issues/38806
+cuda12 = ["jax[cuda12]>=0.6.2,!=0.10.2,!=0.11.0"]
+cuda13 = ["jax[cuda13]>=0.6.2,!=0.10.2,!=0.11.0"]
 
 [project.urls]
 Homepage = "https://github.com/bartz-org/bartz"

--- a/uv.lock
+++ b/uv.lock
@@ -292,9 +292,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "equinox", specifier = ">=0.12.2" },
-    { name = "jax", specifier = ">=0.6.2,!=0.10.2" },
-    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.6.2,!=0.10.2" },
-    { name = "jax", extras = ["cuda13"], marker = "extra == 'cuda13'", specifier = ">=0.6.2,!=0.10.2" },
+    { name = "jax", specifier = ">=0.6.2,!=0.10.2,!=0.11.0" },
+    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.6.2,!=0.10.2,!=0.11.0" },
+    { name = "jax", extras = ["cuda13"], marker = "extra == 'cuda13'", specifier = ">=0.6.2,!=0.10.2,!=0.11.0" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "scipy", specifier = ">=1.15.3" },


### PR DESCRIPTION
Excludes jax 0.11.0 from the accepted versions due to https://github.com/jax-ml/jax/issues/38806, in the core dependency and the cuda extras. The pre-existing WORKAROUND comment for the 0.10.2 exclusion is folded into the new one, now targeting jax<0.12 as the removal condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)