### PR TITLE
Port infra fixes from rbartpackages

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -82,9 +82,12 @@ jobs:
           echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
       - name: Wait for it to finish so its coverage artifact exists
+        # --exit-status fails this job if the merge run failed, as if docs and
+        # tests were jobs of one run; recover by re-running this job, or
+        # dispatch release-docs.yml manually with the coverage run id.
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh run watch --repo "$GITHUB_REPOSITORY" "${{ steps.source.outputs.run_id }}" || true
+        run: gh run watch --exit-status --repo "$GITHUB_REPOSITORY" "${{ steps.source.outputs.run_id }}"
 
       - name: Re-trigger as a workflow_dispatch to deploy
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,13 @@ jobs:
 
       - name: Determine base ref
         id: refs
-        run: echo "from=${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (startsWith(github.ref, 'refs/heads/') && github.event.before) || '' }}" >> "$GITHUB_OUTPUT"
+        run: |
+          from='${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (startsWith(github.ref, 'refs/heads/') && github.event.before) || '' }}'
+          # The first push to a branch reports the all-zeros SHA as `before`:
+          # there is no prior commit to diff against, so blank it out and let
+          # the "all files" run below provide coverage.
+          if [ "$from" = '0000000000000000000000000000000000000000' ]; then from=''; fi
+          echo "from=$from" >> "$GITHUB_OUTPUT"
 
       - name: Run pre-commit on changed files
         # even if we run it on all files below, it's convenient to see if something fails in new changes first

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,13 +145,14 @@ repos:
         # first line, so the match runs from the opening `"""` to the first newline
         # or the closing `"""` (whichever comes first), one-line and multi-line
         # docstrings alike. Matches an attribute assignment or annotation line (one
-        # not ending in `:`, i.e. not a def/class header) followed by a same-indent
+        # not ending in `:`, i.e. not a def/class header, possibly just a bare `)`
+        # closing a multi-line assignment) followed by a same-indent
         # `"""` whose first line holds a lone `:` (not `::`) outside any ``code``
         # span or :role:`target`, with real text after it (a colon at end of line
         # is harmless: napoleon then keeps it in the description). Reword to drop
         # the colon.
         language: pygrep
-        entry: '^(?P<i>[ \t]+)\S[^\n]*[^\n:\s]\n(?P=i)"""(?:``[^`]*``|:[A-Za-z0-9_+.:-]+:`[^`\n]+`|`[^`\n]+`|(?!""")[^:`\n])*:(?!:)(?![A-Za-z0-9_+.:-]+:`)[ \t]*(?!""")\S'
+        entry: '^(?P<i>[ \t]+)\S(?:[^\n]*[^\n:\s])?\n(?P=i)"""(?:``[^`]*``|:[A-Za-z0-9_+.:-]+:`[^`\n]+`|`[^`\n]+`|(?!""")[^:`\n])*:(?!:)(?![A-Za-z0-9_+.:-]+:`)[ \t]*(?!""")\S'
         args: [--multiline]
         types: [python]
       - id: forbid-lam-lamda

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -137,6 +137,23 @@ repos:
         entry: '^(?P<i>[ \t]*)Returns[ \t]*\n(?P=i)-+[ \t]*\n(?P=i)(?!""")\S[^\n]*\n(?:[ \t]*\n)*(?P=i)(?!""")(?!\w+[ \t]*\n(?P=i)-+[ \t]*$)\S'
         args: [--multiline]
         types: [python]
+      - id: forbid-napoleon-type-colon
+        name: forbid stray colon in first line of attribute docstrings
+        # A lone colon in the first line of an attribute docstring makes sphinx
+        # napoleon split it into a `:type:` field, leaking a stray "Type: <text
+        # before the colon>" into the html. Napoleon only inspects the docstring's
+        # first line, so the match runs from the opening `"""` to the first newline
+        # or the closing `"""` (whichever comes first), one-line and multi-line
+        # docstrings alike. Matches an attribute assignment or annotation line (one
+        # not ending in `:`, i.e. not a def/class header) followed by a same-indent
+        # `"""` whose first line holds a lone `:` (not `::`) outside any ``code``
+        # span or :role:`target`, with real text after it (a colon at end of line
+        # is harmless: napoleon then keeps it in the description). Reword to drop
+        # the colon.
+        language: pygrep
+        entry: '^(?P<i>[ \t]+)\S[^\n]*[^\n:\s]\n(?P=i)"""(?:``[^`]*``|:[A-Za-z0-9_+.:-]+:`[^`\n]+`|`[^`\n]+`|(?!""")[^:`\n])*:(?!:)(?![A-Za-z0-9_+.:-]+:`)[ \t]*(?!""")\S'
+        args: [--multiline]
+        types: [python]
       - id: forbid-lam-lamda
         name: forbid `lam`/`lamda` identifier (use `lambda_` per PEP 8)
         language: pygrep

--- a/scripts/opt.py
+++ b/scripts/opt.py
@@ -323,7 +323,7 @@ class ConfigParams:
     """Maximum tree depth; passed through `make_p_nonterminal`."""
 
     weights: Literal['none', 'scalar', 'vector']
-    """`init`'s ``error_scale`` mode: ``'none'`` (unset), ``'scalar'`` (shape ``(n,)``), or ``'vector'`` (shape ``(k, n)``, multivariate heteroskedasticity; requires ``k``)."""
+    """`init`'s ``error_scale`` mode, ``'none'`` (unset), ``'scalar'`` (shape ``(n,)``), or ``'vector'`` (shape ``(k, n)``, multivariate heteroskedasticity; requires ``k``)."""
 
     num_trees: int
     """`init`'s ``num_trees`` kwarg."""

--- a/src/bartz/mcmcloop/_trace.py
+++ b/src/bartz/mcmcloop/_trace.py
@@ -198,7 +198,7 @@ class MainTraceWithTrainPred(MainTrace):
         Float32[Array, '*chains_and_samples n']
         | Float32[Array, '*chains_and_samples k n']
     ) = field(chains=CHAIN_AXIS, samples=0, data=-1)
-    """The latent predictions at the training points: offset plus the scaled sum
+    """The latent predictions at the training points, offset plus the scaled sum
     of trees."""
 
     @classmethod

--- a/src/bartz/mcmcstep/_reduction.py
+++ b/src/bartz/mcmcstep/_reduction.py
@@ -242,11 +242,11 @@ class AutoBatchedReduction(ReductionConfig):
     """
 
     min_batch_size: float = field(static=True, default=128.0)
-    """Minimum datapoints per batch on gpu: caps the batch count at
+    """Minimum datapoints per batch on gpu; caps the batch count at
     ``n / min_batch_size``."""
 
     beta_sm: float = field(static=True, default=48.0)
-    """Batches per streaming multiprocessor on gpu: the batch count saturates at
+    """Batches per streaming multiprocessor on gpu; the batch count saturates at
     ``beta_sm * n_sms * m ** -gamma``, with `n_sms` the gpu's SM count and ``m``
     the multivariate work per datapoint."""
 


### PR DESCRIPTION
Back-ports the infra fixes made in rbartpackages after the last bartz→rbartpackages sync (rbartpackages#33 and its extraction fixes).

- `release-docs.yml`: `gh run watch` now uses `--exit-status` instead of `|| true`, so the docs redeploy is not dispatched when the merge run failed.
- New `forbid-napoleon-type-colon` pre-commit hook: a lone colon in the first line of an attribute docstring makes napoleon leak a stray "Type: ..." field into the html. The hook caught four existing offenders, reworded here (verified the built html is clean).
- `tests.yml`: the diff lint/cov base ref blanks out the all-zeros `before` SHA reported on the first push to a branch, instead of diffing against a nonexistent commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)