### PR TITLE
fix: work around jax gpu scatter perf regression

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,7 +31,9 @@ To check the code you write:
 - run the unit tests relevant to your code changes with `uv run pytest ...`
     - not all tests right away because the full test suite takes a long time to run
 - at the end of debugging, run the full test suite to check everything works
-    - `make tests` will run everything with 2 workers and prints a lot of stuff, faster and more complete than `uv run pytest`
+    - use `uv run pytest`; we have a `make tests`, but its config is pretty heavy on a laptop and blocks other agents/people working in parallel
+    - skip this if you think the focused tests were sufficient for a surgical change
+- do not update changelog, we write it before release
 
 ## Architecture
 
@@ -111,8 +113,11 @@ Interface hierarchy:
         - `split` is a class and you use it like this: `keys = split(key); x = random.gen(keys.pop(), ...); y = vmapped_func(keys.pop(1000), ...)`
         - don't pass a `split` object to functions, follow the jax convention that the first argument is a single random key
     - use jnp.square(x), jnp.sqrt(x), lax.rsqrt(x), jnp.reciprocal(x) instead of x**2, x**0.5, x**-0/5, 1/x
+    - jax supports in-place operators (which actually create new arrays), use them
+        - for example, do `x += ...`, not `x = x + ...` where `x` is a jax array
 - other **python** conventions:
     - use dicts as if they were frozendicts when possible: e.g., do `d = dict(d, a=1, b=2)` to set values instead of `d['a'] = 1` or `d.update(a=1)`, safer
+        - other useful pattern: `d = dict(**d, a=1, b=2)` to check the keys are not already present
         - related: prefer tuples to lists
         - related: make all dataclasses frozen unless you really need mutability
     - type annotations:

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ clean:
 # other groups are balanced just under it. Rough tests-old cost per group (wall
 # seconds, ~= the deduped CI `--durations` table; re-measure after big changes):
 #   misc ~755  iface-v5v7 ~730  iface-v6 ~760  iface-v4 ~850  bart-v1 ~725  bart-v23 ~670
-GROUP_misc        := tests/test_mcmcstep.py tests/test_mcmcloop.py tests/test_dgp.py tests/test_prepcovars.py tests/test_debug.py tests/test_meta.py tests/test_naming.py tests/test_docs.py 'tests/test_interface.py::test_equiv_sharding[v7]' -k "not TestMultichain"
+GROUP_misc        := tests/test_mcmcstep.py tests/test_mcmcloop.py tests/test_dgp.py tests/test_prepcovars.py tests/test_debug.py tests/test_meta.py tests/test_naming.py tests/test_docs.py tests/test_workarounds.py 'tests/test_interface.py::test_equiv_sharding[v7]' -k "not TestMultichain"
 GROUP_iface-v5v7  := tests/test_interface.py -k "(v5 and TestWithCachedBart) or (v7 and not test_equiv_sharding)"
 GROUP_iface-v6    := tests/test_interface.py -k "v6 or (v5 and not TestWithCachedBart)"
 GROUP_iface-v4    := tests/test_interface.py -k "(v4 and not test_equiv_sharding) or not (v2 or v3 or v4 or v5 or v6 or v7)"

--- a/benchmarks/speed.py
+++ b/benchmarks/speed.py
@@ -116,7 +116,7 @@ Kind = Literal['plain', 'weights', 'binary', 'sparse', 'multivariate']
 def get_default_platform() -> str:
     """Get the default JAX platform (cpu, gpu)."""
     with ensure_compile_time_eval():
-        return jnp.zeros(0).platform()  # ty: ignore[unresolved-attribute]
+        return jnp.zeros(0).platform()
 
 
 def simple_init(  # noqa: C901, PLR0915

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "equinox>=0.12.2",
-    # WORKAROUND(jax<0.12): see https://github.com/jax-ml/jax/issues/38806
-    "jax>=0.6.2,!=0.10.2,!=0.11.0",
+    "jax>=0.6.2",
     "jaxtyping>=0.3.2",
     "numpy>=2.2.6",
     "scipy>=1.15.3",
@@ -46,9 +45,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# WORKAROUND(jax<0.12): see https://github.com/jax-ml/jax/issues/38806
-cuda12 = ["jax[cuda12]>=0.6.2,!=0.10.2,!=0.11.0"]
-cuda13 = ["jax[cuda13]>=0.6.2,!=0.10.2,!=0.11.0"]
+cuda12 = ["jax[cuda12]>=0.6.2"]
+cuda13 = ["jax[cuda13]>=0.6.2"]
 
 [project.urls]
 Homepage = "https://github.com/bartz-org/bartz"

--- a/src/bartz/__init__.py
+++ b/src/bartz/__init__.py
@@ -28,6 +28,11 @@ Super-fast BART (Bayesian Additive Regression Trees) in Python.
 See the manual at https://bartz-org.github.io/bartz/docs
 """
 
+from bartz import _workarounds
+
+# apply before importing anything that could initialize a jax backend
+_workarounds.apply_workarounds()
+
 from bartz import BART, grove, mcmcloop, mcmcstep, prepcovars, stochtree  # noqa: F401
 from bartz._interface import (  # noqa: F401
     Bart,

--- a/src/bartz/_interface.py
+++ b/src/bartz/_interface.py
@@ -35,7 +35,7 @@ from pathlib import Path
 
 # WORKAROUND(python<3.15): use frozendict instead of MappingProxyType
 from types import MappingProxyType
-from typing import Any, Literal, Protocol, TypedDict, runtime_checkable
+from typing import Any, Literal, Protocol, TypedDict, cast, runtime_checkable
 from warnings import warn
 
 import jax
@@ -1764,7 +1764,7 @@ def _determine_devices(
         # set device=None because if the devices were not specified explicitly
         # we may be in the case where computation will follow data placement,
         # do not disturb jax as the user may be playing with vmap, jit, reshard...
-        platform = y_train.platform()  # ty: ignore[call-non-callable]
+        platform = cast(Literal['cpu', 'gpu'], y_train.platform())
         return platform, None, jax.devices(platform)
     else:
         msg = 'not possible to infer device from `y_train`, please set `devices`'

--- a/src/bartz/_workarounds.py
+++ b/src/bartz/_workarounds.py
@@ -32,7 +32,6 @@ import re
 from importlib.util import find_spec
 
 import jax
-from jax._src.lib import xla_client
 
 FTZ_ATOMICS_OPTION = '-nvptx-allow-ftz-atomics'
 
@@ -68,6 +67,10 @@ def option_in_parsed_flags(option: str) -> bool:
     this function right after modifying ``XLA_FLAGS`` both locks the change in
     (if XLA had not read the variable yet) and reports whether it was read.
     """
+    # import locally so that a future jaxlib dropping this internal module
+    # can not break `import bartz` on jax versions that don't need the fix
+    from jaxlib import xla_client  # noqa: PLC0415
+
     serialized = xla_client.CompileOptions().SerializeAsString()
     return option.encode() in serialized
 

--- a/src/bartz/_workarounds.py
+++ b/src/bartz/_workarounds.py
@@ -1,0 +1,127 @@
+# bartz/src/bartz/_workarounds.py
+#
+# Copyright (c) 2026, The Bartz Contributors
+#
+# This file is part of bartz.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Workarounds for upstream bugs, applied when bartz is imported.
+
+Set the environment variable ``BARTZ_SKIP_XLA_WORKAROUND=1`` to disable them.
+"""
+
+import os
+import re
+from importlib.util import find_spec
+
+import jax
+from jax._src.lib import xla_client
+
+FTZ_ATOMICS_OPTION = '-nvptx-allow-ftz-atomics'
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    """Extract the leading numeric triplet of a version string."""
+    match = re.match(r'^(\d+)\.(\d+)\.(\d+)', version)
+    assert match is not None, version
+    major, minor, patch = match.groups()
+    return int(major), int(minor), int(patch)
+
+
+def add_backend_extra_option(xla_flags: str, option: str) -> str:
+    """Return `xla_flags` with `option` added to ``--xla_backend_extra_options``."""
+    prefix = '--xla_backend_extra_options='
+    tokens = xla_flags.split()
+    for i, token in enumerate(tokens):
+        if token.startswith(prefix):
+            value = token.removeprefix(prefix)
+            tokens[i] = prefix + (f'{value},{option}' if value else option)
+            break
+    else:
+        tokens.append(prefix + option)
+    return ' '.join(tokens)
+
+
+def option_in_parsed_flags(option: str) -> bool:
+    """Check `option` is in the backend extra options XLA parsed from ``XLA_FLAGS``.
+
+    XLA reads ``XLA_FLAGS`` only once per process, on the first use of a jax
+    backend; later changes to the environment variable are silently ignored.
+    Constructing a `CompileOptions` triggers that one-time read, so calling
+    this function right after modifying ``XLA_FLAGS`` both locks the change in
+    (if XLA had not read the variable yet) and reports whether it was read.
+    """
+    serialized = xla_client.CompileOptions().SerializeAsString()
+    return option.encode() in serialized
+
+
+def cuda_plugin_installed() -> bool:
+    """Check if a jax cuda plugin package is installed."""
+    return any(find_spec(f'jax_cuda{v}_plugin') is not None for v in (12, 13))
+
+
+def cuda_devices_available() -> bool:
+    """Check if jax can actually use cuda devices."""
+    try:
+        devices = jax.devices('cuda')
+    except RuntimeError:
+        return False
+    else:
+        return bool(devices)
+
+
+def fix_gpu_scatter_performance() -> None:
+    """Restore native f32 atomics in gpu scatters on affected jax versions."""
+    # WORKAROUND(jax<=0.11.0): jax 0.10.2 and 0.11.0 ship an LLVM that lowers
+    # the f32 atomic adds in gpu scatters to CAS loops, catastrophically slow
+    # under index contention; this hidden LLVM option restores the native
+    # atomics (and pre-0.10.2 numerics). See
+    # https://github.com/jax-ml/jax/issues/38806. If the next jax release
+    # contains the LLVM fix, delete this whole file and its uses.
+    if not ((0, 10, 2) <= parse_version(jax.__version__) <= (0, 11, 0)):
+        return
+    if not cuda_plugin_installed():
+        return
+    xla_flags = os.environ.get('XLA_FLAGS', '')
+    if FTZ_ATOMICS_OPTION in xla_flags or '--xla_gpu_ftz=true' in xla_flags.lower():
+        return  # the user already took care of it
+    os.environ['XLA_FLAGS'] = add_backend_extra_option(xla_flags, FTZ_ATOMICS_OPTION)
+    if not option_in_parsed_flags(FTZ_ATOMICS_OPTION) and cuda_devices_available():
+        msg = (
+            f'jax {jax.__version__} has a severe performance regression in gpu '
+            'scatter operations (https://github.com/jax-ml/jax/issues/38806). '
+            f'bartz works around it by adding {FTZ_ATOMICS_OPTION} to the '
+            'XLA_FLAGS environment '
+            'variable, but XLA has already read XLA_FLAGS (that happens on the '
+            'first use of a jax backend), so the workaround is ineffective. '
+            'Either import bartz before using jax, or set '
+            f"XLA_FLAGS='--xla_backend_extra_options={FTZ_ATOMICS_OPTION}' "
+            'before starting Python, or use a jax version other than '
+            '0.10.2/0.11.0. Set BARTZ_SKIP_XLA_WORKAROUND=1 to ignore this '
+            'error and run with slow gpu scatters.'
+        )
+        raise RuntimeError(msg)
+
+
+def apply_workarounds() -> None:
+    """Apply all workarounds; invoked on ``import bartz``."""
+    if os.environ.get('BARTZ_SKIP_XLA_WORKAROUND', '') not in ('', '0'):
+        return
+    fix_gpu_scatter_performance()

--- a/tests/test_BART.py
+++ b/tests/test_BART.py
@@ -662,7 +662,7 @@ def test_sequential_guarantee(kw: dict, subtests: SubTests) -> None:
     ].reshape(bart1.ndpost, n)
 
     with subtests.test('shift burn-in'):
-        rtol = 0 if bart1.yhat_train.platform() == 'cpu' else 2e-6  # ty: ignore[unresolved-attribute]
+        rtol = 0 if bart1.yhat_train.platform() == 'cpu' else 2e-6
         # on gpu typically it works fine, but in one case there was a small
         # numerical difference in one of two chains
         assert_close_matrices(bart1.yhat_train, bart2_yhat_train, rtol=rtol)
@@ -680,7 +680,7 @@ def test_sequential_guarantee(kw: dict, subtests: SubTests) -> None:
     ]
 
     with subtests.test('change thinning'):
-        rtol = 0 if bart1.yhat_train.platform() == 'cpu' else 2e-6  # ty: ignore[unresolved-attribute]
+        rtol = 0 if bart1.yhat_train.platform() == 'cpu' else 2e-6
         # on gpu typically it works fine, but in one case there was a small
         # numerical difference in one of two chains
         assert_close_matrices(
@@ -1466,7 +1466,7 @@ def test_polars(kw: dict[str, Any]) -> None:
     bart2 = mc_gbart(**kw)
     pred2 = bart2.predict(kw['x_test'])
 
-    rtol = 0 if pred.platform() == 'cpu' else 2e-6  # ty: ignore[unresolved-attribute]
+    rtol = 0 if pred.platform() == 'cpu' else 2e-6
 
     assert_close_matrices(bart.yhat_train, bart2.yhat_train, rtol=rtol)
     if bart.sigma is not None:

--- a/tests/test_dgp.py
+++ b/tests/test_dgp.py
@@ -770,7 +770,7 @@ class TestErrorCorrelation:
         )
         # on gpu the identity-correlation path goes through a matmul that the
         # independent path skips, so the two diverge by float noise
-        rtol = 1e-4 if ident.z.platform() != 'cpu' else 1e-6  # ty: ignore[unresolved-attribute]
+        rtol = 1e-4 if ident.z.platform() != 'cpu' else 1e-6
         assert_close_matrices(ident.z, indep.z, rtol=rtol)
         assert_close_matrices(ident.y, indep.y, rtol=rtol)
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -908,7 +908,7 @@ def test_sequential_guarantee(bkw: BartKW, subtests: SubTests) -> None:
     with subtests.test('shift burn-in'):
         rtol = (
             0
-            if bart1.predict('train', kind='latent_samples').platform() == 'cpu'  # ty: ignore[unresolved-attribute]
+            if bart1.predict('train', kind='latent_samples').platform() == 'cpu'
             else 2e-6
         )
         assert_close_matrices(
@@ -933,7 +933,7 @@ def test_sequential_guarantee(bkw: BartKW, subtests: SubTests) -> None:
     with subtests.test('change thinning'):
         rtol = (
             0
-            if bart1.predict('train', kind='latent_samples').platform() == 'cpu'  # ty: ignore[unresolved-attribute]
+            if bart1.predict('train', kind='latent_samples').platform() == 'cpu'
             else 2e-6
         )
         assert_close_matrices(
@@ -1184,7 +1184,7 @@ def test_missing_ignored(bkw: BartKW, keys: split) -> None:
     # note: don't use predict('train') because that may rely on `resid` being clean
     yhat1 = bart1.predict(kw['x_train'], kind='latent_samples')
     yhat2 = bart2.predict(kw['x_train'], kind='latent_samples')
-    rtol = 0 if yhat1.platform() == 'cpu' else 1e-5  # ty: ignore[unresolved-attribute]
+    rtol = 0 if yhat1.platform() == 'cpu' else 1e-5
     assert_close_matrices(yhat1, yhat2, rtol=rtol, reduce_rank=True)
 
     # check resid_inexact_integral separately because it's not upstream of anything
@@ -2220,11 +2220,7 @@ def test_permutation_invariance(bkw: BartKW, keys: split) -> None:
     def check_equal(
         path: KeyPath, x1: Shaped[Array, '*shape'], x2: Shaped[Array, '*shape']
     ) -> None:
-        rtol = condf(
-            leaf_tree,
-            1e-4 if x1.platform() != 'cpu' else 1e-5,  # ty: ignore[unresolved-attribute]
-            1e-3,
-        )
+        rtol = condf(leaf_tree, 1e-4 if x1.platform() != 'cpu' else 1e-5, 1e-3)
         assert_close_matrices(
             x2, x1, err_msg=f'{keystr(path)}: ', rtol=rtol, reduce_rank=True
         )
@@ -2815,11 +2811,7 @@ def test_vmap(bkw: BartKW, keys: split) -> None:
     # reduced-precision leaves quantize the slightly different float32 reductions
     # of vmapped vs looped runs, so equivalence holds only to the rounding floor;
     # the leaves and everything derived from them carry this loss
-    rtol = condf(
-        singles[0]._mcmc_state.forest.leaf_tree,
-        1e-4 if platform != 'cpu' else 1e-5,
-        1e-3,
-    )
+    rtol = condf(singles[0]._mcmc_state.forest.leaf_tree, 1e-4, 1e-3)
 
     def check(a: Shaped[Array, '*shape'], b: Shaped[Array, '*shape']) -> None:
         assert_close_matrices(a, b, rtol=rtol, reduce_rank=True)
@@ -2985,7 +2977,7 @@ def test_polars(bkw: BartKW) -> None:
     x_test_pl = pl.DataFrame(numpy.array(bkw.x_test).T)
     pred2 = bart2.predict(x_test_pl, kind='latent_samples')
 
-    rtol = 0 if pred.platform() == 'cpu' else 2e-6  # ty: ignore[unresolved-attribute]
+    rtol = 0 if pred.platform() == 'cpu' else 2e-6
 
     assert_close_matrices(
         bart.predict('train', kind='latent_samples'),
@@ -3662,7 +3654,7 @@ def test_get_error_sdev_values(bkw: BartKW) -> None:
 def test_devices_platform(bkw: BartKW) -> None:
     """Check that passing `devices='cpu'/'gpu'` ends up on the expected device."""
     bart1 = Bart(**bkw.kw)
-    platform = bart1._main_trace.grow_prop_count.platform()  # ty: ignore[unresolved-attribute]
+    platform = bart1._main_trace.grow_prop_count.platform()
     kw2 = dict(bkw.kw, devices=platform)
     bart2 = Bart(**kw2)
     # `_device` records whether `devices` was passed explicitly, so it may
@@ -3680,7 +3672,7 @@ def assert_identical_bart(bart1: OriginalBart, bart2: OriginalBart) -> None:
         assert x1.dtype == x2.dtype
         assert x1.sharding.is_equivalent_to(x2.sharding, x1.ndim)
         if jnp.issubdtype(x1.dtype, jnp.floating):
-            rtol = 1e-4 if x1.platform() != 'cpu' else 1e-5  # ty: ignore[unresolved-attribute]
+            rtol = 1e-4 if x1.platform() != 'cpu' else 1e-5
             assert_close_matrices(
                 x1, x2, rtol=rtol, err_msg=keystr(path), reduce_rank=True
             )

--- a/tests/test_jaxext.py
+++ b/tests/test_jaxext.py
@@ -369,7 +369,10 @@ class TestAutoBatch:
             return x * 2
 
         x = random.uniform(keys.pop(), (10,))
-        with pytest.raises(ValueError, match='Expected None'):
+        # the message wording depends on the jax version and on which pytree
+        # prefix check trips first
+        match = 'Expected None|different types at key path'
+        with pytest.raises(ValueError, match=match):
             autobatch(func, 32, 0, None)(x)
 
 

--- a/tests/test_mcmcstep.py
+++ b/tests/test_mcmcstep.py
@@ -773,7 +773,7 @@ class TestReduction:
         exact = assert_array_equal  # the count path must match exactly
         # on gpu the matmul method contracts via tf32 (~1e-3 relative error); cpu
         # keeps the tight tolerance, so accuracy is still fully checked there
-        rtol = 1e-3 if indices.platform() != 'cpu' else 1e-5  # ty: ignore[unresolved-attribute]
+        rtol = 1e-3 if indices.platform() != 'cpu' else 1e-5
         close = partial(assert_close_matrices, rtol=rtol, atol=1e-6, reduce_rank=True)
 
         # each case invokes a reduce function `f` (a config's `_reduce` or the

--- a/tests/test_stochtree.py
+++ b/tests/test_stochtree.py
@@ -578,7 +578,7 @@ def test_jit(continuous_data: _Data, keys: split) -> None:
     # devices can't be inferred from a jit tracer, so pre-determine the platform;
     # rm_const requires concrete max_split values, so disable it for tracing.
     bart_kwargs: dict = {
-        'devices': jax.devices(args['y'].platform()),  # ty: ignore[unresolved-attribute]
+        'devices': jax.devices(args['y'].platform()),
         'rm_const': False,
     }
 

--- a/tests/test_workarounds.py
+++ b/tests/test_workarounds.py
@@ -1,0 +1,160 @@
+# bartz/tests/test_workarounds.py
+#
+# Copyright (c) 2026, The Bartz Contributors
+#
+# This file is part of bartz.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Test the XLA_FLAGS workaround for the jax gpu scatter regression."""
+
+import os
+import subprocess
+import sys
+from textwrap import dedent
+
+import jax
+import pytest
+
+from bartz import _workarounds
+from bartz._jaxext import get_default_device
+
+
+def test_parse_version() -> None:
+    """Check version strings are reduced to numeric triplets."""
+    assert _workarounds.parse_version('0.11.0') == (0, 11, 0)
+    assert _workarounds.parse_version('0.12.0.dev20260718') == (0, 12, 0)
+    with pytest.raises(AssertionError):
+        _workarounds.parse_version('garbage')
+    with pytest.raises(AssertionError):
+        _workarounds.parse_version('garbage0.11.0')
+
+
+def test_add_backend_extra_option() -> None:
+    """Check the option is merged into XLA_FLAGS without clobbering it."""
+    option = _workarounds.FTZ_ATOMICS_OPTION
+    add = _workarounds.add_backend_extra_option
+    prefix = '--xla_backend_extra_options='
+    assert add('', option) == f'{prefix}{option}'
+    assert (
+        add('--xla_dump_to=/tmp/x', option) == f'--xla_dump_to=/tmp/x {prefix}{option}'
+    )
+    assert add(f'{prefix}-foo --xla_gpu_autotune_level=0', option) == (
+        f'{prefix}-foo,{option} --xla_gpu_autotune_level=0'
+    )
+    assert add(prefix, option) == f'{prefix}{option}'
+
+
+def test_cuda_detection() -> None:
+    """Check the cuda detection helpers against the test platform."""
+    if get_default_device().platform == 'gpu':
+        assert _workarounds.cuda_plugin_installed()
+        assert _workarounds.cuda_devices_available()
+    elif _workarounds.cuda_devices_available():
+        # tests forced to cpu on a gpu machine: the plugin must still be there
+        assert _workarounds.cuda_plugin_installed()
+
+
+def test_raises_when_too_late(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check the error raised when the workaround can't be applied on gpu."""
+    monkeypatch.setattr(jax, '__version__', '0.11.0')
+    monkeypatch.setattr(_workarounds, 'cuda_plugin_installed', lambda: True)
+    monkeypatch.setattr(_workarounds, 'cuda_devices_available', lambda: True)
+    monkeypatch.setattr(_workarounds, 'option_in_parsed_flags', lambda _option: False)
+    monkeypatch.setenv('XLA_FLAGS', '')
+    with pytest.raises(RuntimeError, match='38806'):
+        _workarounds.fix_gpu_scatter_performance()
+
+
+def test_skip_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check BARTZ_SKIP_XLA_WORKAROUND disables the workarounds."""
+    monkeypatch.setenv('BARTZ_SKIP_XLA_WORKAROUND', '1')
+    monkeypatch.setattr(
+        _workarounds,
+        'fix_gpu_scatter_performance',
+        lambda: pytest.fail('workaround not skipped'),
+    )
+    _workarounds.apply_workarounds()
+
+
+def run_in_subprocess(code: str) -> subprocess.CompletedProcess:
+    """Run python code in a fresh interpreter with pristine XLA state."""
+    env = dict(os.environ)
+    env.pop('XLA_FLAGS', None)
+    env.pop('BARTZ_SKIP_XLA_WORKAROUND', None)
+    return subprocess.run(  # noqa: S603, the code is a trusted literal
+        [sys.executable, '-c', dedent(code)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=120,
+    )
+
+
+def test_applied_in_time() -> None:
+    """Check applying the workaround before any jax backend use locks it in."""
+    result = run_in_subprocess("""
+        import os
+
+        import jax
+
+        from bartz import _workarounds as w
+
+        jax.__version__ = '0.11.0'
+        w.cuda_plugin_installed = lambda: True
+        w.fix_gpu_scatter_performance()
+        assert w.FTZ_ATOMICS_OPTION in os.environ['XLA_FLAGS']
+        assert w.option_in_parsed_flags(w.FTZ_ATOMICS_OPTION)
+        """)
+    assert result.returncode == 0, result.stderr
+
+
+def test_too_late() -> None:
+    """Check what happens if a jax backend is used before applying.
+
+    The workaround is ineffective: silently if there is no gpu, with an error
+    otherwise.
+    """
+    result = run_in_subprocess("""
+        import os
+
+        os.environ['BARTZ_SKIP_XLA_WORKAROUND'] = '1'
+
+        import jax
+
+        jax.devices()  # initialize backends, locking XLA_FLAGS
+
+        from bartz import _workarounds as w
+
+        jax.__version__ = '0.11.0'
+        w.cuda_plugin_installed = lambda: True
+
+        w.cuda_devices_available = lambda: False
+        w.fix_gpu_scatter_performance()  # no error without gpus
+        assert w.FTZ_ATOMICS_OPTION in os.environ['XLA_FLAGS']
+        assert not w.option_in_parsed_flags(w.FTZ_ATOMICS_OPTION)
+
+        os.environ['XLA_FLAGS'] = ''
+        w.cuda_devices_available = lambda: True
+        w.fix_gpu_scatter_performance()  # error with gpus
+        """)
+    assert result.returncode != 0
+    assert 'RuntimeError' in result.stderr
+    assert '38806' in result.stderr

--- a/tests/test_workarounds.py
+++ b/tests/test_workarounds.py
@@ -63,12 +63,30 @@ def test_add_backend_extra_option() -> None:
 
 def test_cuda_detection() -> None:
     """Check the cuda detection helpers against the test platform."""
-    if get_default_device().platform == 'gpu':
+    if get_default_device().platform == 'gpu':  # pragma: no cover, needs gpu
         assert _workarounds.cuda_plugin_installed()
         assert _workarounds.cuda_devices_available()
-    elif _workarounds.cuda_devices_available():
+    elif _workarounds.cuda_devices_available():  # pragma: no cover, needs gpu
         # tests forced to cpu on a gpu machine: the plugin must still be there
         assert _workarounds.cuda_plugin_installed()
+
+
+def test_cuda_devices_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check gpu detection with a stubbed `jax.devices`."""
+    monkeypatch.setattr(jax, 'devices', lambda _backend: ['gpu0'])
+    assert _workarounds.cuda_devices_available()
+
+    def no_cuda(_backend: str) -> list:
+        msg = 'Unknown backend'
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(jax, 'devices', no_cuda)
+    assert not _workarounds.cuda_devices_available()
+
+
+def test_option_in_parsed_flags() -> None:
+    """Check a probe option is not found in the flags XLA parsed at startup."""
+    assert not _workarounds.option_in_parsed_flags('-definitely-not-a-real-option')
 
 
 def test_raises_when_too_late(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -80,6 +98,19 @@ def test_raises_when_too_late(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv('XLA_FLAGS', '')
     with pytest.raises(RuntimeError, match='38806'):
         _workarounds.fix_gpu_scatter_performance()
+
+
+def test_user_already_set_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Check the workaround defers to user-provided XLA flags."""
+    monkeypatch.setattr(jax, '__version__', '0.11.0')
+    monkeypatch.setattr(_workarounds, 'cuda_plugin_installed', lambda: True)
+    for flags in (
+        f'--xla_backend_extra_options={_workarounds.FTZ_ATOMICS_OPTION}',
+        '--XLA_GPU_FTZ=true',
+    ):
+        monkeypatch.setenv('XLA_FLAGS', flags)
+        _workarounds.fix_gpu_scatter_performance()
+        assert os.environ['XLA_FLAGS'] == flags
 
 
 def test_skip_env_var(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -228,7 +228,7 @@ source = { editable = "." }
 dependencies = [
     { name = "equinox" },
     { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jax", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jax", version = "0.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jaxtyping", version = "0.3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "jaxtyping", version = "0.3.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -243,11 +243,11 @@ dependencies = [
 [package.optional-dependencies]
 cuda12 = [
     { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, extra = ["cuda12"], marker = "python_full_version < '3.11'" },
-    { name = "jax", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, extra = ["cuda12"], marker = "python_full_version >= '3.11'" },
+    { name = "jax", version = "0.10.2", source = { registry = "https://pypi.org/simple" }, extra = ["cuda12"], marker = "python_full_version >= '3.11'" },
 ]
 cuda13 = [
     { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jax", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, extra = ["cuda13"], marker = "python_full_version >= '3.11'" },
+    { name = "jax", version = "0.10.2", source = { registry = "https://pypi.org/simple" }, extra = ["cuda13"], marker = "python_full_version >= '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -292,9 +292,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "equinox", specifier = ">=0.12.2" },
-    { name = "jax", specifier = ">=0.6.2,!=0.10.2,!=0.11.0" },
-    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.6.2,!=0.10.2,!=0.11.0" },
-    { name = "jax", extras = ["cuda13"], marker = "extra == 'cuda13'", specifier = ">=0.6.2,!=0.10.2,!=0.11.0" },
+    { name = "jax", specifier = ">=0.6.2" },
+    { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda12'", specifier = ">=0.6.2" },
+    { name = "jax", extras = ["cuda13"], marker = "extra == 'cuda13'", specifier = ">=0.6.2" },
     { name = "jaxtyping", specifier = ">=0.3.2" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "scipy", specifier = ">=1.15.3" },
@@ -1059,7 +1059,7 @@ version = "0.13.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jax", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jax", version = "0.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "jaxtyping", version = "0.3.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "jaxtyping", version = "0.3.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "typing-extensions" },
@@ -1510,7 +1510,7 @@ cuda12 = [
 
 [[package]]
 name = "jax"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1527,26 +1527,26 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "jaxlib", version = "0.10.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jaxlib", version = "0.10.2", source = { registry = "https://pypi.org/simple" } },
     { name = "ml-dtypes" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
     { name = "opt-einsum" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/49/b082387119c4a6bc7596296bbdc6bce034628cdd2845ebb27304cbca3624/jax-0.10.1.tar.gz", hash = "sha256:11672410faf8752429eb9a131de203dc488a2a3a012d509baa2b39878008810d", size = 2718178, upload-time = "2026-05-20T14:54:09.441Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/73/eb91d98fcadfa2cbcfdd4e417ab116e47eb20882acc5ee678e47c35d6b57/jax-0.10.2.tar.gz", hash = "sha256:bf77428a8c2e6904c4f46d5ab12aa5cfc6cad2179f07f7e4c0fc75ac86ef0639", size = 2775110, upload-time = "2026-06-17T23:44:57.818Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/6e/5087e0347188f6970aba1ffbd0018754d23c3f3461e9f21785f2f27a02c2/jax-0.10.1-py3-none-any.whl", hash = "sha256:47f3192c76e9e3358de1b106a8af5e943fccb10510903f25d96ea53652729134", size = 3150973, upload-time = "2026-05-20T14:51:30.066Z" },
+    { url = "https://files.pythonhosted.org/packages/89/82/5ab5211079a151b6f661529369c0c8e98ec64cabf5c0cf22a0a05af124d8/jax-0.10.2-py3-none-any.whl", hash = "sha256:724d73c4678d8b06f6a6ab4db1b8a2fea8cd4f1e2c2564f99601634ec7b8d1c6", size = 3219515, upload-time = "2026-06-17T23:42:41.259Z" },
 ]
 
 [package.optional-dependencies]
 cuda12 = [
-    { name = "jax-cuda12-plugin", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, extra = ["with-cuda"] },
-    { name = "jaxlib", version = "0.10.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jax-cuda12-plugin", version = "0.10.2", source = { registry = "https://pypi.org/simple" }, extra = ["with-cuda"] },
+    { name = "jaxlib", version = "0.10.2", source = { registry = "https://pypi.org/simple" } },
 ]
 cuda13 = [
     { name = "jax-cuda13-plugin", extra = ["with-cuda"] },
-    { name = "jaxlib", version = "0.10.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jaxlib", version = "0.10.2", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -1563,7 +1563,7 @@ wheels = [
 
 [[package]]
 name = "jax-cuda12-pjrt"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1580,8 +1580,8 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e0/2ad8ab2d3c299ec1befccf88e6618f4d8d8b05f430a3e52f11d2f66609e9/jax_cuda12_pjrt-0.10.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:07046311b1657ec77cb4b0719a3e3a829194e2e1dd530bbe543182f6a4260ca6", size = 159056392, upload-time = "2026-05-20T14:51:33.827Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/a1/47c08a81760cae84c4a4aa720f3fc1ce3bac6f7aafa5ab82c302d7946f07/jax_cuda12_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4c50a469f1b7c2fbba278d5b6932fe33de41f833b333cae28151422ec456857d", size = 164801423, upload-time = "2026-05-20T14:51:39.431Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b0/e1d392ee24ecd53caa202194746cb12058befde5882d1f3307922829783f/jax_cuda12_pjrt-0.10.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b6f2d66548ee1ee910a836b5fe3d0ebbe1da04a62d0f468ba4822189036a32b3", size = 169847949, upload-time = "2026-06-17T23:42:44.729Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/326facd192b7dc0731e43b30f5ada5ef235e2a3325a151d94ed3db041536/jax_cuda12_pjrt-0.10.2-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:806d1fd29038b6acf5a2b289dd62192abea977ee26aef60ea295b1d28a23acf8", size = 174364763, upload-time = "2026-06-17T23:42:49.931Z" },
 ]
 
 [[package]]
@@ -1625,7 +1625,7 @@ with-cuda = [
 
 [[package]]
 name = "jax-cuda12-plugin"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1642,21 +1642,21 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "jax-cuda12-pjrt", version = "0.10.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "jax-cuda12-pjrt", version = "0.10.2", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/d4/21b2e73904adde337ad7055e77e3fa6e29070c59a80c57cf09a58ae6eeaa/jax_cuda12_plugin-0.10.1-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:5e2dcc05a6bcfcbeb237bc210e06fea1d7aaed61a018da6d880f8c30626a626f", size = 7868129, upload-time = "2026-05-20T14:51:43.409Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/0e/f92abde980d004eef341b12e4a405ff003b42a52308ec2e6d0f68373aed1/jax_cuda12_plugin-0.10.1-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:8eeff5f604cf40f0fb2d2a31aaf847866d222e58aa3702d1c40c75b085a67c8b", size = 7913427, upload-time = "2026-05-20T14:51:45.221Z" },
-    { url = "https://files.pythonhosted.org/packages/22/f3/131a1bf5e666821f97e7e515063bd408259ce025682c2c0748960aceb669/jax_cuda12_plugin-0.10.1-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:34d62485ee26d8d69b336291808a8f88656797607e2df01082fc0824292e11d9", size = 7862325, upload-time = "2026-05-20T14:51:47.033Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/3f/cabd3c791ff5042df157609e00e96440ccaba69f72bccd8e3470d85fdd48/jax_cuda12_plugin-0.10.1-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:83e7740f6536a3dc82cdf1d510c944bcbdcfd1b36abf875adc4013fea3bf934e", size = 7910790, upload-time = "2026-05-20T14:51:49.731Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/88/df891143630655fd4fc7cccdbbc443df86b2dfa40b1304b6da5cc345f232/jax_cuda12_plugin-0.10.1-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:580cd3cc74449650b0700e0df2b99a193b928f7c0603d4b30425dc3c0fdd0ec6", size = 7862581, upload-time = "2026-05-20T14:51:51.602Z" },
-    { url = "https://files.pythonhosted.org/packages/86/4d/3ff82b88c7195ee9fccc27a506e9d365490e95ae996a54f377ae91bed69f/jax_cuda12_plugin-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:a6a0c121964fb5fb6f5f422f822217ea93bc44dba9514632270e7fe8dbdd212c", size = 7910858, upload-time = "2026-05-20T14:51:53.287Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/a6/cdc78544faf428821e19b1c47c51adb3e3dbd3e0dc0085a37194c888a5a6/jax_cuda12_plugin-0.10.1-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:9a19aeff8deef7e8fe546591630bd506432e145cad69bcd4e3484e9c788e7774", size = 7877268, upload-time = "2026-05-20T14:51:55.155Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/f5/88dc48b2c323260b3089691447fa79eb95a11712c35f6f9cd97eb20d9488/jax_cuda12_plugin-0.10.1-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:f1c7b8b9cc87e6d3f8712385f48ecf50f0bf7b9630ba328d60785a8100ae9dd4", size = 7920953, upload-time = "2026-05-20T14:51:56.743Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/24/3c1cb0ac8c4467ee1b05eee4230d8cdceb6ce510f9d74a566755c6b78f46/jax_cuda12_plugin-0.10.1-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:7b5a6ca52886d5a17d77aa60505203eb0e2e5871c11e69da6360944161685b3b", size = 7863082, upload-time = "2026-05-20T14:51:58.34Z" },
-    { url = "https://files.pythonhosted.org/packages/63/e1/61a8855e56f1a8d346e41ff050a527ce0cb4bb1409f0fa133f874cf98dd6/jax_cuda12_plugin-0.10.1-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:7366212ed7cf22958f91c64092268e5749a1ee3e14d9b78b1105fa7fc1af5ed6", size = 7911468, upload-time = "2026-05-20T14:52:00.648Z" },
-    { url = "https://files.pythonhosted.org/packages/29/5f/e563690de106e3e8afc19e330d62d9263dec83299fc6de064b579465fa4b/jax_cuda12_plugin-0.10.1-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:027ddc77880cca23445bb7e6553e5627c64dd66d5097beb8cd2ccdbfb9b25b06", size = 7877559, upload-time = "2026-05-20T14:52:02.23Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/42/46b36497a6ea3243b1c293affe27c8dc560165d1645a61e6dea5e8a7efdb/jax_cuda12_plugin-0.10.1-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:26b1855199995cd7faa0f7de3258737d2ad05e9bc04f19f0a0b2c07240b818d0", size = 7921330, upload-time = "2026-05-20T14:52:03.84Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/25/ac0e8a02fd46e34d4d0e67214fc022688701d3c26ea93de15d1b2c74b0d6/jax_cuda12_plugin-0.10.2-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:9cd0937070bbd28e44b91435b52c7225c8ed6cb37ddb6a90e9c246873a03f9cd", size = 8098522, upload-time = "2026-06-17T23:42:53.439Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/55/627b9ed487e82047c6f7d1dc8174a31df7c350093292a3c664183908faf1/jax_cuda12_plugin-0.10.2-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:76bbfece2f6effb4e8908eb8a5fbf1abbc1125de667683ec2ffba51c63dc57af", size = 8144162, upload-time = "2026-06-17T23:42:55.513Z" },
+    { url = "https://files.pythonhosted.org/packages/94/4a/382ec14e57d774148b079c3d251fc9b9e1ed7f92dd2327823f35e0a968a7/jax_cuda12_plugin-0.10.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:767a1482dbf652688403c4e22ff01470e1add13c48f9d817169fd8f7440afce5", size = 8093630, upload-time = "2026-06-17T23:42:57.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/25/19ee8936b00ca74a12bfaebd4703695cee2407f954a6e4e67cdd7f82b7bf/jax_cuda12_plugin-0.10.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:4eb6e8e0992fd9897db2468da33f276ae414ec84dc436804124404430502eeac", size = 8141521, upload-time = "2026-06-17T23:42:58.483Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/a9c4ea148d31843764383b26fd66b38cfedad9a6dbf08db634a23d9312c3/jax_cuda12_plugin-0.10.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:69776ac849112f4fc2d6fa616f8772106daff38fcdb825c4e39f47e878f27610", size = 8093605, upload-time = "2026-06-17T23:43:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/92/07/3098ae537e68d76bbc98ed61d53e9856f63f4f1bd64f8aeb4d432dad1290/jax_cuda12_plugin-0.10.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:948a988927cb10843b501a215181ccb1daed3fa70531b2f1ae0842fe1c08b05e", size = 8141236, upload-time = "2026-06-17T23:43:01.55Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0c/ff1e1975ef108cb2e45deacf5dea812822efaf3210af075f464abd40399c/jax_cuda12_plugin-0.10.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:febd9d3f488d182090758936042ad647a60470923715b48a385bc312cb943c63", size = 8108408, upload-time = "2026-06-17T23:43:03.398Z" },
+    { url = "https://files.pythonhosted.org/packages/09/c2/04c70eb73beb4df23f49b72d159ca74ee31cccb1be95cdab7491a5ebd259/jax_cuda12_plugin-0.10.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:1f1e20fba0aaa3f28ab0a3273754c8c098fa40b74bf4dac5b76c9f2a70425487", size = 8151184, upload-time = "2026-06-17T23:43:05.106Z" },
+    { url = "https://files.pythonhosted.org/packages/95/34/5d5b2993f6b7bbfe781920671de61036faffa5a8bf3740b4ca23d790b6f9/jax_cuda12_plugin-0.10.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:4946ec57ddb795e2da8288ceb1ceddd58c2a204a0f7765af89eae486a1d3ace7", size = 8094107, upload-time = "2026-06-17T23:43:06.546Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ac/85bc07d7a0766c7999f9bdfcf7f7cb2487fd0eb5d6bbe2bd41a3a54cd379/jax_cuda12_plugin-0.10.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:0c7a0204155585cc1c4fcb30c66b7f881b38e57e1f0d8e97d48e1654bf0d27f8", size = 8141889, upload-time = "2026-06-17T23:43:08.018Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/7d/9fa25e24b96ab06217e1e3dd311a80f3534076bb1b19d46cbc8cf9aa55b9/jax_cuda12_plugin-0.10.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:c26a7dd5e71c9edf203b95480f02ec4ad60c9c7e11e38b7310b1fd1dd03ba116", size = 8108639, upload-time = "2026-06-17T23:43:09.651Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c2/98fa02ba204f5dc88680128129fbc7cd833d5b5ddae2734af93ef85db853/jax_cuda12_plugin-0.10.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:c539b052056e8181082fa2635f17e098b3f625d87da53ba35470a2c13480801d", size = 8151505, upload-time = "2026-06-17T23:43:11.023Z" },
 ]
 
 [package.optional-dependencies]
@@ -1677,33 +1677,33 @@ with-cuda = [
 
 [[package]]
 name = "jax-cuda13-pjrt"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/8e/57eebc0c4d6d63bad64f7443cbc96d3e3c5535fa4992af58568ad7388cbb/jax_cuda13_pjrt-0.10.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:7dd9f518876857e238a9a63abc185b277e9435470cc286b92209ef79d51d03cf", size = 113795506, upload-time = "2026-05-20T14:52:06.61Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/74/05adf1f245de3b37518ba1e7e668cdc38ec0291313ab63fc0768089f8baa/jax_cuda13_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:af8042c7697fb6faa0cc4851d4f5e0504878ea1f6b6fc067255f449016336a6f", size = 119552553, upload-time = "2026-05-20T14:52:11.087Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/2a/756474bf57cf8cdf200f4120813d0c8db7463c7301d6f394c4ede4737b1f/jax_cuda13_pjrt-0.10.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b28f4940d09405ece084e50c91634f4bb1d43a8497b9d734f40007ee07281aec", size = 119860632, upload-time = "2026-06-17T23:43:13.768Z" },
+    { url = "https://files.pythonhosted.org/packages/55/09/17733fa3ef4f183b70d5e55f7fe7c712017fac7ec7a22e39dab1539acdb8/jax_cuda13_pjrt-0.10.2-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:a97e9cabe0e21d8dbcc70bd909ca1c34cd546d3ce2d94b4cd907a8d4f6179f6a", size = 124395292, upload-time = "2026-06-17T23:43:21.424Z" },
 ]
 
 [[package]]
 name = "jax-cuda13-plugin"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jax-cuda13-pjrt" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/cc/488c5ffece62d563063f1f026b590064cc34c8803c314d15e7c84f52eee1/jax_cuda13_plugin-0.10.1-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:309a0727d975aed0d25a1f0af47c9259ce88b74f5e1b8ce12eff03c8573dff55", size = 7261264, upload-time = "2026-05-20T14:52:14.91Z" },
-    { url = "https://files.pythonhosted.org/packages/14/ca/34a2d2bf5afc2f0cabfce279bfb1ffd1ffea87babd098a8a1ef7a8941a7c/jax_cuda13_plugin-0.10.1-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:b77ba9e9b43cb5a56fe84eac904ab20013e6fd538a39828485e852fa4265f2a6", size = 7308740, upload-time = "2026-05-20T14:52:16.548Z" },
-    { url = "https://files.pythonhosted.org/packages/88/1e/6f8135ac3f6dbee231392131cb278fabccbceddbc0a1a160a579bfe7b37a/jax_cuda13_plugin-0.10.1-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:a4f8c2ad46fcf6edbe09b66578ec5fd7f8d189fcdb5d0a2500e473c5eebfc824", size = 7254249, upload-time = "2026-05-20T14:52:18.2Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/c2/6f9911b2a7f1f333320b3600118f13b57b43248288f2e4a3b276aa95c85e/jax_cuda13_plugin-0.10.1-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:6799bf4e59574f5a49638fa4e1b6a43ddea75cc7eb19f726c4f6d94aa1e05cdd", size = 7306406, upload-time = "2026-05-20T14:52:20.056Z" },
-    { url = "https://files.pythonhosted.org/packages/47/cf/d6d807cbbb4e61103291a34856b32766b252c96a39897bf4e0143942f030/jax_cuda13_plugin-0.10.1-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:a31e7859ecebfa0680eca260ea64046d5c54c7596d734897526ebeb89d54e48b", size = 7255426, upload-time = "2026-05-20T14:52:21.663Z" },
-    { url = "https://files.pythonhosted.org/packages/80/80/ec043edee9db3debf5074fe5fd0431c6fea3f94d1b9a53458b35cd30544d/jax_cuda13_plugin-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:9070b1af00ebc7f5d6f20aafb789058f53812afd85e237dce0f1709a52cfd0f8", size = 7306050, upload-time = "2026-05-20T14:52:23.216Z" },
-    { url = "https://files.pythonhosted.org/packages/44/94/d480e1fb807cf67c3796200dca01cbe4c75dfa82ce64460b90c944e218cf/jax_cuda13_plugin-0.10.1-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:6baea37967bd9759f5bc014d8d6291782332478f746302f46fd08a9009a23304", size = 7268591, upload-time = "2026-05-20T14:52:24.77Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/7f/da438722130ca56ec5b15a3318c477418088aaa818480280816e6ce6259d/jax_cuda13_plugin-0.10.1-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:699a984d67b040f6dd26bae1b9326d748c62cafee769a9050085f953b42db0e5", size = 7316498, upload-time = "2026-05-20T14:52:26.47Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e7/3a0194e0e6b74bf22e7bf4bd495042204aa5eaee278823780fc3aef9acb5/jax_cuda13_plugin-0.10.1-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:b836b1eb29ae3e64d435def9c74b0ced435c3584cc17a29f3ff52c549274a059", size = 7256172, upload-time = "2026-05-20T14:52:28.037Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/0c/63c9e91d038ee0aaef39bed13efb526ed6bf5c4ced8d5ea5dcdd88868c34/jax_cuda13_plugin-0.10.1-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:a556bd9e68155c7a8a43148fcdd2b582678e2270b86ea1749b1880be0aca7d2e", size = 7306774, upload-time = "2026-05-20T14:52:30.429Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/42/537fa75f685b90175c7e10239ec7ad713c759e6057c4d695719feaa1ebf2/jax_cuda13_plugin-0.10.1-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:ee4b25a4f00a696b2f45c2a3a4693aeeed4408914c3784496d747e6655172e20", size = 7269049, upload-time = "2026-05-20T14:52:32.302Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/c1/a40da5ef96b0d030a22f31c01e3b372e2f7527b85df592ca907d44824576/jax_cuda13_plugin-0.10.1-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:24315ca6d00c992125a5bd38471e1c3bd30c9d0f3c26286ca29fd82f29883452", size = 7317313, upload-time = "2026-05-20T14:52:33.894Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/21/187a90838c12eff0f96bcc4f673cf5efb9ea52fdcd6b86328ba73857da1a/jax_cuda13_plugin-0.10.2-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:9452844e878fd36c414c4ce0e124ad3d89d2844862561a06bcef68bb83679739", size = 7434705, upload-time = "2026-06-17T23:43:24.165Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/24/c5157ec907633759b7935eda5622720bf27d753ce0e6552e4e2acaa53552/jax_cuda13_plugin-0.10.2-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:4dfbac70e6258c66e9f2c17df170e05cc86580d8fa25ed78d670491084581382", size = 7484417, upload-time = "2026-06-17T23:43:25.768Z" },
+    { url = "https://files.pythonhosted.org/packages/32/93/26900739da476f65e9ce0ae5d23ef236ca9508d64862ef2e39abe95ed45a/jax_cuda13_plugin-0.10.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:5cbcf4f9835c1026d93e6eb8aef33a0f91cfd96004cc2d3c423a6c86bc728434", size = 7429850, upload-time = "2026-06-17T23:43:27.068Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/77/2cdc37266b423927128d6810374a2650572b65c9a0292a5d57ce5cfea752/jax_cuda13_plugin-0.10.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:f7df0de38e460befe3d6216bd12bcd9759289759110c5e620baa05d977ae4ccf", size = 7481940, upload-time = "2026-06-17T23:43:30.947Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/f1/623532c25a59b7a7ae56b8f758502ec8a6f03684ff9bfde457072412e589/jax_cuda13_plugin-0.10.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:c8dd182b36f5c5d23285e0878becc6d9961ce1f555d1767ee6f0f8f373765f48", size = 7429777, upload-time = "2026-06-17T23:43:32.305Z" },
+    { url = "https://files.pythonhosted.org/packages/11/92/7e3b6ed7f830deea2069be2497c123839114dab565bf2f160924e90a9235/jax_cuda13_plugin-0.10.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:f70672c3961bf55a18badceb793c78d6d7fc782c53e297fdd2e1e8517994f656", size = 7481386, upload-time = "2026-06-17T23:43:33.755Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/53/adb7d565968b655bc352adac2b68e19b6b93b1792e591076ac6bbfa9c0e5/jax_cuda13_plugin-0.10.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:63d85fc5705e46b4fd192e102df405f54071fd5f3dde1d88b36036f1fd8d2cc7", size = 7444506, upload-time = "2026-06-17T23:43:35.024Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/4f/451386895bf26645b8e0660419fb6495f18bf9d01a4147583f0b4123668c/jax_cuda13_plugin-0.10.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:37d6f049533004f7a59218cd480c4d31af0e04f6ad13431380c64e4d48eac4f6", size = 7491712, upload-time = "2026-06-17T23:43:36.587Z" },
+    { url = "https://files.pythonhosted.org/packages/68/97/7e917e638ae286ad314be7c8f55170153b0566c65f1de998fcb8fb4786b4/jax_cuda13_plugin-0.10.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:dbc795a2021e07d299cd5d305554c3d5f48c5951fb467e05cb47e1dba02b2167", size = 7430444, upload-time = "2026-06-17T23:43:38.138Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/97/3b1a80c97d1a1aad8133ce601a6cf4f238f41e11c2bd4860a69543a5d365/jax_cuda13_plugin-0.10.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:661d3dd23b9aa8fa86647472e7b1303460f4643ee516fe707912e5ab90dfd3ff", size = 7482446, upload-time = "2026-06-17T23:43:39.53Z" },
+    { url = "https://files.pythonhosted.org/packages/82/de/031ea70db49182330a61753ae421c204459785e700f7439b450dd7ebadce/jax_cuda13_plugin-0.10.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:0325f77b0cdd9ad083bb0451cf29d4ac6c684b8d1ec2f01d1bebe825bc430c1c", size = 7444795, upload-time = "2026-06-17T23:43:41.27Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/91/585e7f54155cc79375efa679b80465872d57f3aa161730a607ff85fb10b8/jax_cuda13_plugin-0.10.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:3a14fa5531b1ec3689726714df450d32d09e930a9fe8a6c10bdb095b88ebd9e8", size = 7491871, upload-time = "2026-06-17T23:43:42.797Z" },
 ]
 
 [package.optional-dependencies]
@@ -1758,7 +1758,7 @@ wheels = [
 
 [[package]]
 name = "jaxlib"
-version = "0.10.1"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -1781,28 +1781,28 @@ dependencies = [
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/e9/43253041a0b28f64a99dfa8a6823de415b1b9723dc8eb8718945bb957b1c/jaxlib-0.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ff0c82cb958d180d26687459962e262b6e1c90f239903c8253cc190067124db4", size = 60802893, upload-time = "2026-05-20T14:52:36.047Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/dd/fe5e06087d79ef014a10fc4d5acba76f585278eb54cdbeb880347600a41c/jaxlib-0.10.1-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:349b131c8b393fe5de2aabec1539f18c6a6ce85680b145c78b068fc56d498472", size = 80280956, upload-time = "2026-05-20T14:52:40.366Z" },
-    { url = "https://files.pythonhosted.org/packages/33/89/8c6dff28eaf86a917622e427caf045ecb85772eaa1679937915e4e5ac8d6/jaxlib-0.10.1-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:9c2f0d6b910e93dd47bbfc3aa54c83950ff6a05955913892d31b034337d89420", size = 85810989, upload-time = "2026-05-20T14:52:45.208Z" },
-    { url = "https://files.pythonhosted.org/packages/83/fd/6b705478e19af3dd384351c91f4b469fef83bb1fa070c45a937ae7dcc335/jaxlib-0.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:f49375e63c4486295e31d3f93b4abeb0a69183cb78484299b135c74bc036ec4c", size = 64802918, upload-time = "2026-05-20T14:52:49.279Z" },
-    { url = "https://files.pythonhosted.org/packages/53/b4/fdb6e989b142d8a8d2093f342cbc5323fe0d4a7217fd899c8ddf9e108a5a/jaxlib-0.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7a4399c7429c87ee6f7ab1e5712c5548ecfabde974ee9f4a12957fea4e35efb8", size = 60816137, upload-time = "2026-05-20T14:52:53.028Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/29/0b4eaaca005708751ff301903a2ca760dcc34175dadb7536498c57a7de85/jaxlib-0.10.1-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:12126603ba472300c62480f86d20972d563143041039d9dea349ad510aa6123c", size = 80294034, upload-time = "2026-05-20T14:52:56.941Z" },
-    { url = "https://files.pythonhosted.org/packages/38/69/2912ab63036e21c72748019e1d8e09e8a1fc3368b3e83fc27898a1858575/jaxlib-0.10.1-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:f3cdf5b7f48470ab5455ab79aab746419694ccb6b52651cc2ce5fb27def03588", size = 85828774, upload-time = "2026-05-20T14:53:01.749Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/8f/993ea419eca6f34fe12613e22a03b93f40e5b1e8e0df18d4060e1313a1fc/jaxlib-0.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:0acf3f8e7dca9074c0327f0f61502845792ca9f82fab23b841b00daa78e85488", size = 64830187, upload-time = "2026-05-20T14:53:05.932Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/76/3b637d4def229015a3035a7b44fac0dcf2536ae337540cdbffc651334d4e/jaxlib-0.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4167213aa00f14bb0d8fbd90f9ded75e976f71ce8baf8c3c44e04c8fb80ea0c1", size = 60815855, upload-time = "2026-05-20T14:53:11.718Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/76/9a1971bc9edb8728a7ba86d2693127ee46add9811230b8452321415fd4e9/jaxlib-0.10.1-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:e53223d8f6861d33c02dd02343fa464700401ff5363784d37c33407218e328b8", size = 80293947, upload-time = "2026-05-20T14:53:15.408Z" },
-    { url = "https://files.pythonhosted.org/packages/20/1d/69a0ba52fb546261e71a7209378ee6059950e9c088a2a18355e01509f474/jaxlib-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:bb073a1224e659e01e8d32d47c000edb52ec2aa8ba97ec22b2228b3a46e5c167", size = 85829861, upload-time = "2026-05-20T14:53:19.773Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/df/48659e2ee57705c63a51525f810fe3e0c87af4ca9f89d4738281a872d58e/jaxlib-0.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:6449f1d4a22324f5f02c843360475783f9fd1d353fe711806cbf4e927d1360ae", size = 64828863, upload-time = "2026-05-20T14:53:24.562Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/34/3f7c95ee1b2555d611f836988a49b522c04b8d186e0528f91d45118089bf/jaxlib-0.10.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:72a7db1242d6b7773340e430c244e73a8d13f82ce83933c0529a8b4b1520dcf3", size = 60934063, upload-time = "2026-05-20T14:53:28.549Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/84/855a2395d299e00e1d9ffd0aecd516b52b81780f3e4ef537527be6d8c1fc/jaxlib-0.10.1-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:649c26ca92e9bbffb3c35226b37893916f20e6b89fb3911ce79b39e5cfb27b46", size = 80402500, upload-time = "2026-05-20T14:53:32.444Z" },
-    { url = "https://files.pythonhosted.org/packages/be/35/153e91a9c770a981d525d845b3f4cdb71a1e119681594a33908e9536bdff/jaxlib-0.10.1-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:cfe75d8a17e0d33a7bed27f32d7a5344a66e8d4af7073973f396e14ff4a9c503", size = 85941210, upload-time = "2026-05-20T14:53:36.982Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/a1/c4d4c0530313c50dd1ba07fff480cfd0c5f18c5ec49742f4a52a6edfd95f/jaxlib-0.10.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9a657554dbe56f3691d377cb99d00b29df14e5638e579e57965f9f69c32c9315", size = 60826189, upload-time = "2026-05-20T14:53:40.73Z" },
-    { url = "https://files.pythonhosted.org/packages/98/71/529b2439b88491e0806ee9fa6191ecf90f4447dfe092e80bd19577c85260/jaxlib-0.10.1-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:93cd9989404f86a21b50c7ff4e850a31f55509664312080978bde97a664d92a9", size = 80300654, upload-time = "2026-05-20T14:53:44.751Z" },
-    { url = "https://files.pythonhosted.org/packages/be/08/0bc4132fb2fe224ee9d83fd60e3650fd4d893b4e5148707a98df8f0333a4/jaxlib-0.10.1-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:26b94e9640b01968cc14b8353dd6b6540d723f30579c78b1f46a477fc4aa196d", size = 85841241, upload-time = "2026-05-20T14:53:49.13Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/de/423d748ce3367bd5ea20d8cc34a7ceb6420da4d41c20b247f54194700d04/jaxlib-0.10.1-cp314-cp314-win_amd64.whl", hash = "sha256:375820799bbf7d515dd4e4d40f3334566b73d3fe64d340afbd6aa897d5d7c486", size = 67301520, upload-time = "2026-05-20T14:53:52.989Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/bf/3f7ce089d62f7ac85ea678925471f7ec88038899e67ab02079c1e7d8ad4e/jaxlib-0.10.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bc52f16bdd61b299efeed7ea8e743e91a118059a463da2ab97196fc05b69ddb7", size = 60935393, upload-time = "2026-05-20T14:53:56.886Z" },
-    { url = "https://files.pythonhosted.org/packages/65/6a/38cf1d4ff8c8f74ec8d567e0aa6e3d2082ab6fc580545f6bb51368da20a9/jaxlib-0.10.1-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:55b0a473fbd57d31dc3935c4cd5c0c38af5f7c1f41300df27923cf46676972ca", size = 80405741, upload-time = "2026-05-20T14:54:01.94Z" },
-    { url = "https://files.pythonhosted.org/packages/16/9e/d3cff171aaf13a09aab26a44d1a27dcbf0d6311e4d855f5d99685965ace3/jaxlib-0.10.1-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:4b0cb8ef960a3723037db63f28ffa20083d90fff6d30085e99d7c63cfa08e4c0", size = 85942183, upload-time = "2026-05-20T14:54:05.91Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2c/7038fc73154307389631b5b2dbe5ac529e1918eecc19a27e6644ad114bbf/jaxlib-0.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5a98873fc867623b81f2bee15d554b8edd6588a183d01fa50d21b1e3db96ff2b", size = 61429039, upload-time = "2026-06-17T23:43:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/66/c6/d69a0a33046f84930b89387861c061996d5207671b35080898679ca9960a/jaxlib-0.10.2-cp311-cp311-manylinux_2_27_aarch64.whl", hash = "sha256:d44565dcfd1b4f60f76d911c6512118a8a4fc764bdef92663fecb8bfccd54f23", size = 81079180, upload-time = "2026-06-17T23:43:48.245Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/27/fb54e3265c0ffcb687f93e9fb761c589acebbe958c3fed1b2c74c3f0e782/jaxlib-0.10.2-cp311-cp311-manylinux_2_27_x86_64.whl", hash = "sha256:1faca3c5d4662cb4a6130a68105d68bb520764817e165d6eebfd6786c0d1f30f", size = 85448560, upload-time = "2026-06-17T23:43:51.724Z" },
+    { url = "https://files.pythonhosted.org/packages/21/bc/31fbb3d892c3cb97c73af9226eca63d60d8e224017145bdb6871d1d24da6/jaxlib-0.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:e7a9214e6b0b9e0825d905573d1bbf2253c20e9d7464a63e085b60519975553f", size = 65867603, upload-time = "2026-06-17T23:43:54.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/93/ee9cc8743191544f65d26ab7eeb82d65968fe60905662d1a5554d056654b/jaxlib-0.10.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47bb7c011515ea862be7e8313f40f9c56cbec09dc98a0fcb5016785fcd454c01", size = 61434612, upload-time = "2026-06-17T23:43:57.808Z" },
+    { url = "https://files.pythonhosted.org/packages/11/06/8cc36021bf74d617c312eeed94c280282bb1bcbb32b63f2a42b10ae41575/jaxlib-0.10.2-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:53b72977ae582c03a9e8e1cdee1efbf8ebc1418270965b0e69eade57acf40331", size = 81085366, upload-time = "2026-06-17T23:44:01.067Z" },
+    { url = "https://files.pythonhosted.org/packages/48/17/38b718af2353dba7753300871e83fbb64a88a772e12727ae27373ab675ce/jaxlib-0.10.2-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:fe88ec443714c4379968b6c109f9fa617c7ad19b802828e4d7bf861cd66da4b7", size = 85467828, upload-time = "2026-06-17T23:44:04.238Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/c2/d41d13826ebdfe62e56cd87ba70fab3bb9fcbea4a6c9086739a91667e5bf/jaxlib-0.10.2-cp312-cp312-win_amd64.whl", hash = "sha256:4b08f5fbc596b83f76308181863996f93d901d1f09cfd4e130a65c1998e1b371", size = 65900139, upload-time = "2026-06-17T23:44:07.476Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/68/eaa4cebe253359196a8e80a33b242959e27d8d2a6ae3d09339f21da2acb8/jaxlib-0.10.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4df530afa354a22dc1747a5d560640450cbb895d49889338a3f58c76a4c76c8e", size = 61434805, upload-time = "2026-06-17T23:44:10.511Z" },
+    { url = "https://files.pythonhosted.org/packages/25/c1/4b884ea5962b6beb3c0f93742db54246bbf8b3274e48b0aca47908e454be/jaxlib-0.10.2-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:45b28b0238697ab74bbcf20411aafb6db42acc31836cc2fd711e5cf056bf9556", size = 81084260, upload-time = "2026-06-17T23:44:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ac/4ee28c65861605945223145fbcd3c9362ec2255ddf7d917574e205548c82/jaxlib-0.10.2-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:9e4818b4a8756fd3918766ca2aa5342125809f4f08a6fe46026d4386e7c23644", size = 85467706, upload-time = "2026-06-17T23:44:17.471Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/9918b0f77a25a1299818c0610305ca2bea38ed90584f4489b60357e2dd39/jaxlib-0.10.2-cp313-cp313-win_amd64.whl", hash = "sha256:c75d6f1df1c9cff08e110b4a21c79560fdc502f4288972d6b117d25dafd44352", size = 65897894, upload-time = "2026-06-17T23:44:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5b/70df11da52a8b1a826184cccc05a3fec8aed76058a980021873fba3069cb/jaxlib-0.10.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4c202d8ff7c1f3b5049dbd8f1e30e52759cd4e0a5835f0b3c7ae076a05818e28", size = 61564746, upload-time = "2026-06-17T23:44:24.421Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/184a648ea5db6c8b1a08fc5784c157b4c557255e009fb56091393df3c6de/jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:b7b029bb95d981566750475b9719a9d6b66ed5dd2748851667899b6cfe075299", size = 81204888, upload-time = "2026-06-17T23:44:27.57Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/5c/539596a55265711d74147913278bcdc38412980be7d74d9c9d860297c486/jaxlib-0.10.2-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:e8b126097d609b0c6e6786e89f6dd6978adc02ebd5f63a1c61293fbac7821305", size = 85583810, upload-time = "2026-06-17T23:44:30.962Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/27471ec9f1d04674f6e62de809412371e097aed3eca7d9483e677c54c214/jaxlib-0.10.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:72eba28b12fee02616fa42aa4b881b4ab62d7757c7843c462401d3fb34a27be4", size = 61446097, upload-time = "2026-06-17T23:44:34.196Z" },
+    { url = "https://files.pythonhosted.org/packages/af/c8/941a7f7f37510f51290a5bd1a413aeef977fb8ba8adc0cfe8391233a764c/jaxlib-0.10.2-cp314-cp314-manylinux_2_27_aarch64.whl", hash = "sha256:f18f56fee90699cfba9b6627045a7a299702cb0e2af82ce180d9a6a7c8048093", size = 81096546, upload-time = "2026-06-17T23:44:37.486Z" },
+    { url = "https://files.pythonhosted.org/packages/69/77/ac054882c220872512df28d16aeb648fe0e651efbb5be4fd7c4817fd88b0/jaxlib-0.10.2-cp314-cp314-manylinux_2_27_x86_64.whl", hash = "sha256:ca34f363197fb0ac4082582ca755007910369e33f8a8ba3d35ed94b71070107d", size = 85472993, upload-time = "2026-06-17T23:44:40.904Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/7d/c592d1fa69c210be0d2743fffc598dfc2f54efa9671c5f6f5d1e151c6f4a/jaxlib-0.10.2-cp314-cp314-win_amd64.whl", hash = "sha256:99818b0a18adc0b899abf4873795e8d65169441d87ab2e5cbb228e73d0f25808", size = 68376553, upload-time = "2026-06-17T23:44:44.968Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9b/91b00ec74985d29708b50420b4103c1f651c8f1c253d4fcb49d1bbb532cd/jaxlib-0.10.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:fc62997fce8831819551a2a5469a818169b09582b5b648c102d11ac7205bb812", size = 61564620, upload-time = "2026-06-17T23:44:48.217Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c7/49d2b19c3b3105c30e1d3af2062e82e1977fb239d3dc3cbb583ef676dda7/jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_aarch64.whl", hash = "sha256:a24d6e3cba263978293eae8b41330d5ccf24d6cdd1a6bcd4e82aff34e767620d", size = 81206365, upload-time = "2026-06-17T23:44:51.419Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/99/006cedf443f4a01f2088651facce79b2105bfb4905bfe9162eb0920a6dfb/jaxlib-0.10.2-cp314-cp314t-manylinux_2_27_x86_64.whl", hash = "sha256:5a2ac7aed7c4e661f67600bbcdec9e589151c1efec91f4cdb8d484af1a45c895", size = 85584458, upload-time = "2026-06-17T23:44:55.377Z" },
 ]
 
 [[package]]
@@ -4148,7 +4148,7 @@ wheels = [
 [package.optional-dependencies]
 jax = [
     { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "jax", version = "0.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "jax", version = "0.10.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 polars = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Un-pins jax 0.10.2/0.11.0 and instead works around the gpu scatter performance regression they ship (https://github.com/jax-ml/jax/issues/38806) at runtime. On import, if an affected jax version and a cuda plugin are installed, bartz adds the hidden LLVM option `-nvptx-allow-ftz-atomics` to `XLA_FLAGS`, restoring native f32 atomics in scatters. If XLA has already parsed `XLA_FLAGS` (backend already initialized) the workaround raises with instructions instead of silently running slow; `BARTZ_SKIP_XLA_WORKAROUND=1` disables everything.

Also replaces a `ty: ignore` in `_interface.py` with a `cast` since the pinned-version constraint that motivated it is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)