### PR TITLE
Loop-free approximate Poisson sampler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,6 +303,7 @@ banned-from = ["jax.random", "jax.lax", "jax.numpy", "jax.tree", "math"]
 "jax.random.PRNGKey".msg = "User jax.random.key"
 "jax.random.gamma".msg = "jax's gamma sampler bloats jitted code with rejection loops; use loggamma from bartz._jaxext.random."
 "jax.random.loggamma".msg = "jax's loggamma sampler bloats jitted code with rejection loops; use loggamma from bartz._jaxext.random."
+"jax.random.poisson".msg = "jax's poisson sampler bloats jitted code with rejection loops; use poisson from bartz._jaxext.random."
 "jax.tree_util.tree_all".msg = "Use jax.tree.all"
 "jax.tree_util.tree_flatten".msg = "Use jax.tree.flatten"
 "jax.tree_util.tree_flatten_with_path".msg = "Use jax.tree.flatten_with_path"

--- a/src/bartz/_jaxext/random/__init__.py
+++ b/src/bartz/_jaxext/random/__init__.py
@@ -25,3 +25,4 @@
 """Additions to :external:py:mod:`jax.random`."""
 
 from bartz._jaxext.random._loggamma import loggamma  # noqa: F401
+from bartz._jaxext.random._poisson import poisson  # noqa: F401

--- a/src/bartz/_jaxext/random/_poisson.py
+++ b/src/bartz/_jaxext/random/_poisson.py
@@ -30,6 +30,7 @@ from jax import custom_jvp, jvp, random
 from jax import numpy as jnp
 from jax.dtypes import canonicalize_dtype
 from jax.scipy.special import ndtr
+from jax.scipy.stats import norm
 from jax.typing import DTypeLike
 from jaxtyping import Array, Float, Integer, Key
 
@@ -90,10 +91,10 @@ def poisson(
     the cdf by Peizer and Pratt [1]_, as presented in [2]_.
 
     The samples carry an approximate derivative w.r.t. `lambda_`, defined by
-    implicit differentiation of the Peizer-Pratt relaxation before rounding:
-    single-sample derivatives are biased, but averaged over samples they
-    estimate derivatives of expected values. The integer cast blocks them, so
-    they only flow with a float `dtype`.
+    implicit differentiation of a continuous relaxation of the cdf before
+    rounding: single-sample derivatives are biased, but averaged over samples
+    they estimate derivatives of expected values, at any ``lambda_ > 0``. The
+    integer cast blocks them, so they only flow with a float `dtype`.
 
     References
     ----------
@@ -128,20 +129,73 @@ def poisson_from_normal(
 
 @poisson_from_normal.defjvp
 def poisson_from_normal_jvp(
-    primals: tuple[Float[Array, '*shape'], Float[Array, '...']],
-    tangents: tuple[Float[Array, '*shape'], Float[Array, '...']],
+    primals: tuple[Float[Array, '*shape'], Float[Array, '*lambda_shape']],
+    tangents: tuple[Float[Array, '*shape'], Float[Array, '*lambda_shape']],
 ) -> tuple[Float[Array, '*shape'], Float[Array, '*shape']]:
-    """Implicit differentiation of the Peizer-Pratt relaxation.
+    """Implicit differentiation of a continuous relaxation of the sampler.
 
-    The continuous root x(z, lambda_) of `peizer_pratt_z(x, lambda_) = z`
-    satisfies, by the implicit function theorem,
-    `dx = (dz - dz/dlambda_ dlambda_) / (dz/dx)`. The partials are evaluated at
-    the root guess, which also stands in for the root below `THETA_SPLIT`.
+    Each branch applies the implicit function theorem to the relaxed root of
+    its own cdf representation: the linearly interpolated truncated cdf below
+    `THETA_SPLIT`, the Peizer-Pratt approximation above.
     """
     z, lambda_ = primals
     z_dot, lambda_dot = tangents
     sample = poisson_from_normal(z, lambda_)
+    small = poisson_cdf_inversion_jvp(z, lambda_, sample, z_dot, lambda_dot)
+    large = poisson_peizer_pratt_jvp(z, lambda_, z_dot, lambda_dot)
+    return sample, jnp.where(lambda_ < THETA_SPLIT, small, large)
 
+
+def poisson_cdf_inversion_jvp(
+    z: Float[Array, '*shape'],
+    lambda_: Float[Array, '*lambda_shape'],
+    k: Float[Array, '*shape'],
+    z_dot: Float[Array, '*shape'],
+    lambda_dot: Float[Array, '*lambda_shape'],
+) -> Float[Array, '*shape']:
+    """Tangent of the root of the linearly interpolated truncated cdf.
+
+    In the cell x in (k - 1, k] the relaxed cdf is F(k - 1) + frac pmf(k),
+    frac = x - (k - 1), and the relaxed root solves
+    F(x, lambda_) = ndtr(z) F(K), K = NUM_TERMS - 1; the implicit function
+    theorem with d F(j)/dlambda_ = -pmf(j) and pmf(k - 1)/pmf(k) = k/lambda_
+    then gives dx elementwise.
+    """
+    # re-run the pmf recurrence, gathering the terms at the sampled value
+    pmf = jnp.exp(-lambda_)
+    cdf = pmf
+    pmf_k = jnp.where(k == 0, pmf, 0.0)
+    cdf_km1 = jnp.zeros_like(k)
+    for j in range(1, NUM_TERMS):
+        cdf_km1 = jnp.where(k == j, cdf, cdf_km1)
+        pmf *= lambda_ / j
+        pmf_k = jnp.where(k == j, pmf, pmf_k)
+        cdf += pmf
+
+    # now cdf and pmf are at K; clip frac against tail cancellation errors
+    u = ndtr(z) * cdf
+    frac = jnp.clip((u - cdf_km1) / pmf_k, 0.0, 1.0)
+
+    dx_z = norm.pdf(z) * cdf / pmf_k
+    # guard k/lambda_ to keep the k = 0 term zero also at lambda_ = 0
+    k_over_lambda = jnp.where(k == 0, 0.0, k / lambda_)
+    dx_lambda = frac + (1 - frac) * k_over_lambda - ndtr(z) * pmf / pmf_k
+    return dx_z * z_dot + dx_lambda * lambda_dot
+
+
+def poisson_peizer_pratt_jvp(
+    z: Float[Array, '*shape'],
+    lambda_: Float[Array, '*lambda_shape'],
+    z_dot: Float[Array, '*shape'],
+    lambda_dot: Float[Array, '*lambda_shape'],
+) -> Float[Array, '*shape']:
+    """Tangent of the root of the Peizer-Pratt relaxation.
+
+    The continuous root x(z, lambda_) of `peizer_pratt_z(x, lambda_) = z`
+    satisfies, by the implicit function theorem,
+    `dx = (dz - dz/dlambda_ dlambda_) / (dz/dx)`. The partials are evaluated at
+    the root guess.
+    """
     # keep the evaluation point inside the domain x > -1/2 of z(x); beyond the
     # bound the sample is pinned at 0 anyway
     x = jnp.maximum(peizer_pratt_root(z, lambda_), -0.4)
@@ -151,7 +205,7 @@ def poisson_from_normal_jvp(
     _, dz_lambda = jvp(lambda ell: peizer_pratt_z(x, ell), (lambda_,), (lambda_dot,))
     _, dz_x = jvp(lambda x: peizer_pratt_z(x, lambda_), (x,), (jnp.ones_like(x),))
 
-    return sample, (z_dot - dz_lambda) / dz_x
+    return (z_dot - dz_lambda) / dz_x
 
 
 def poisson_cdf_inversion(

--- a/src/bartz/_jaxext/random/_poisson.py
+++ b/src/bartz/_jaxext/random/_poisson.py
@@ -78,6 +78,11 @@ def poisson(
     -------
     Array of Poisson(lambda_) samples.
 
+    Raises
+    ------
+    ValueError
+        If `lambda_` does not broadcast to `shape`.
+
     Notes
     -----
     Below a mean of 7 the pmf is truncated and inverted directly; above, the
@@ -102,7 +107,10 @@ def poisson(
     dtype = canonicalize_dtype(dtype)
     compute_dtype = jnp.promote_types(jnp.result_type(lambda_), jnp.float32)
     shape = jnp.shape(lambda_) if shape is None else tuple(shape)
-    lambda_ = jnp.broadcast_to(jnp.asarray(lambda_, compute_dtype), shape)
+    if jnp.broadcast_shapes(shape, jnp.shape(lambda_)) != shape:
+        msg = f'lambda_ shape {jnp.shape(lambda_)} does not broadcast to {shape}'
+        raise ValueError(msg)
+    lambda_ = jnp.asarray(lambda_, compute_dtype)
 
     z = random.normal(key, shape, compute_dtype)
     return poisson_from_normal(z, lambda_).astype(dtype)
@@ -110,7 +118,7 @@ def poisson(
 
 @custom_jvp
 def poisson_from_normal(
-    z: Float[Array, '*shape'], lambda_: Float[Array, '*shape']
+    z: Float[Array, '*shape'], lambda_: Float[Array, '...']
 ) -> Float[Array, '*shape']:
     """Map a standard normal variate to a Poisson(lambda_) variate."""
     small = poisson_cdf_inversion(ndtr(z), lambda_)
@@ -120,8 +128,8 @@ def poisson_from_normal(
 
 @poisson_from_normal.defjvp
 def poisson_from_normal_jvp(
-    primals: tuple[Float[Array, '*shape'], Float[Array, '*shape']],
-    tangents: tuple[Float[Array, '*shape'], Float[Array, '*shape']],
+    primals: tuple[Float[Array, '*shape'], Float[Array, '...']],
+    tangents: tuple[Float[Array, '*shape'], Float[Array, '...']],
 ) -> tuple[Float[Array, '*shape'], Float[Array, '*shape']]:
     """Implicit differentiation of the Peizer-Pratt relaxation.
 
@@ -147,25 +155,25 @@ def poisson_from_normal_jvp(
 
 
 def poisson_cdf_inversion(
-    u: Float[Array, '*shape'], lambda_: Float[Array, '*shape']
+    u: Float[Array, '*shape'], lambda_: Float[Array, '...']
 ) -> Float[Array, '*shape']:
     """Invert the cdf truncated to the first `NUM_TERMS` values."""
-    k = jnp.arange(NUM_TERMS, dtype=lambda_.dtype).reshape(
-        (NUM_TERMS, *lambda_.ndim * (1,))
-    )
-    logpmf = xlogy(k, lambda_) - lambda_ - gammaln(k + 1)
-    cdf = jnp.cumsum(jnp.exp(logpmf), axis=0)
-    # scale u by the top cdf value: this makes the comparison immune to the
-    # roundoff of the cdf normalization when u saturates to 1, and piles the
-    # truncated tail mass on the last value of the table
-    u *= cdf[-1, ...]
-    # the sum counts bools, which is exact in any dtype; produce it directly as
-    # float to match the other branch
-    return jnp.sum(cdf < u, axis=0, dtype=u.dtype)
+    k = jnp.arange(NUM_TERMS, dtype=lambda_.dtype)
+
+    # this is normalized later, but keep it normalized anyway (lambda_ term)
+    # to avoid overflows in the intermediate jnp.exp(logpmf)
+    logpmf = xlogy(k, lambda_[..., None]) - lambda_[..., None] - gammaln(k + 1)
+
+    cdf = jnp.cumsum(jnp.exp(logpmf), axis=-1)
+
+    # re-normalize because of truncation and float rounding
+    u *= cdf[..., -1]
+
+    return jnp.sum(cdf < u[..., None], axis=-1).astype(u.dtype)
 
 
 def poisson_peizer_pratt(
-    z: Float[Array, '*shape'], lambda_: Float[Array, '*shape']
+    z: Float[Array, '*shape'], lambda_: Float[Array, '...']
 ) -> Float[Array, '*shape']:
     """Invert the Peizer-Pratt cdf approximation Pr[X <= x] ~ Phi(z(x)).
 
@@ -191,7 +199,7 @@ def poisson_peizer_pratt(
 
 
 def peizer_pratt_root(
-    z: Float[Array, '*shape'], lambda_: Float[Array, '*shape']
+    z: Float[Array, '*shape'], lambda_: Float[Array, '...']
 ) -> Float[Array, '*shape']:
     """Cornish-Fisher approximation of the root of `peizer_pratt_z(x, .) = z`."""
     s = jnp.sqrt(lambda_)
@@ -201,7 +209,7 @@ def peizer_pratt_root(
 
 
 def peizer_pratt_z(
-    x: Float[Array, '*shape'], lambda_: Float[Array, '*shape']
+    x: Float[Array, '*shape'], lambda_: Float[Array, '...']
 ) -> Float[Array, '*shape']:
     """Peizer-Pratt z(x) such that Pr[X <= x] ~ Phi(z(x)), for x > -1/2."""
     y = (x + 0.5) / lambda_

--- a/src/bartz/_jaxext/random/_poisson.py
+++ b/src/bartz/_jaxext/random/_poisson.py
@@ -1,0 +1,231 @@
+# bartz/src/bartz/_jaxext/random/_poisson.py
+#
+# Copyright (c) 2026, The Bartz Contributors
+#
+# This file is part of bartz.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Loop-free sampler for Poisson random variables."""
+
+from collections.abc import Sequence
+
+from jax import custom_jvp, jvp, random
+from jax import numpy as jnp
+from jax.dtypes import canonicalize_dtype
+from jax.scipy.special import gammaln, ndtr, xlogy
+from jax.typing import DTypeLike
+from jaxtyping import Array, Float, Integer, Key
+
+from bartz._jaxext import jit
+
+# below this mean, sample by inverting the truncated cdf directly; above,
+# invert the Peizer-Pratt normal approximation of the cdf, whose max cdf error
+# at the split is ~ 6e-5 (chi-square-detectable only beyond ~3e7 samples)
+THETA_SPLIT = 7.0
+
+# number of pmf terms for the truncated cdf; the truncated tail mass
+# Pr[X > 22 | theta=7] ~ 3e-6 is below the Peizer-Pratt error at the split
+NUM_TERMS = 23
+
+# Peizer-Pratt continuity correction constant (0 for simplicity, 0.02 for more
+# accuracy)
+EPS = 0.02
+
+
+@jit(static_argnums=(2, 3))
+def poisson(
+    key: Key[Array, ''],
+    lambda_: Float[Array, '...'] | float,
+    shape: Sequence[int] | None = None,
+    dtype: DTypeLike = int,
+) -> Integer[Array, '...'] | Float[Array, '...']:
+    """Faster approximate Poisson sampler.
+
+    Loop-free replacement for `jax.random.poisson`. It is approximate: the
+    total variation distance from the exact distribution is below 1e-4, worst
+    around ``lambda_ = 7`` (see Notes).
+
+    Parameters
+    ----------
+    key
+        JAX random key.
+    lambda_
+        The mean parameter, broadcasted with `shape`.
+    shape
+        Shape of the output. If not specified, it is `lambda_.shape`.
+    dtype
+        Dtype of the output. Defaults to the canonical int. Pass a float dtype
+        to propagate derivatives w.r.t. `lambda_` (see Notes).
+
+    Returns
+    -------
+    Array of Poisson(lambda_) samples.
+
+    Notes
+    -----
+    Below a mean of 7 the pmf is truncated and inverted directly; above, the
+    sample is obtained by inverting the very accurate normal approximation of
+    the cdf by Peizer and Pratt [1]_, as presented in [2]_.
+
+    The samples carry an approximate derivative w.r.t. `lambda_`, defined by
+    implicit differentiation of the Peizer-Pratt relaxation before rounding:
+    single-sample derivatives are biased, but averaged over samples they
+    estimate derivatives of expected values. The integer cast blocks them, so
+    they only flow with a float `dtype`.
+
+    References
+    ----------
+    .. [1] Peizer, D. B., & Pratt, J. W. (1968). A Normal Approximation for
+       Binomial, F, Beta, and other Common, Related Tail Probabilities, I.
+       Journal of the American Statistical Association, 63(324), 1416-1456.
+       https://doi.org/10.1080/01621459.1968.10480938
+    .. [2] Johnson, N. L., Kemp, A. W., & Kotz, S. (2005). Univariate discrete
+       distributions (3rd ed). Wiley. Page 168.
+    """
+    dtype = canonicalize_dtype(dtype)
+    compute_dtype = jnp.promote_types(jnp.result_type(lambda_), jnp.float32)
+    shape = jnp.shape(lambda_) if shape is None else tuple(shape)
+    lambda_ = jnp.broadcast_to(jnp.asarray(lambda_, compute_dtype), shape)
+
+    z = random.normal(key, shape, compute_dtype)
+    return poisson_from_normal(z, lambda_).astype(dtype)
+
+
+@custom_jvp
+def poisson_from_normal(
+    z: Float[Array, '*shape'], lambda_: Float[Array, '*shape']
+) -> Float[Array, '*shape']:
+    """Map a standard normal variate to a Poisson(lambda_) variate."""
+    small = poisson_cdf_inversion(ndtr(z), lambda_)
+    large = poisson_peizer_pratt(z, lambda_)
+    return jnp.where(lambda_ < THETA_SPLIT, small, large)
+
+
+@poisson_from_normal.defjvp
+def poisson_from_normal_jvp(
+    primals: tuple[Float[Array, '*shape'], Float[Array, '*shape']],
+    tangents: tuple[Float[Array, '*shape'], Float[Array, '*shape']],
+) -> tuple[Float[Array, '*shape'], Float[Array, '*shape']]:
+    """Implicit differentiation of the Peizer-Pratt relaxation.
+
+    The continuous root x(z, lambda_) of `peizer_pratt_z(x, lambda_) = z`
+    satisfies, by the implicit function theorem,
+    `dx = (dz - dz/dlambda_ dlambda_) / (dz/dx)`. The partials are evaluated at
+    the root guess, which also stands in for the root below `THETA_SPLIT`.
+    """
+    z, lambda_ = primals
+    z_dot, lambda_dot = tangents
+    sample = poisson_from_normal(z, lambda_)
+
+    # keep the evaluation point inside the domain x > -1/2 of z(x); beyond the
+    # bound the sample is pinned at 0 anyway
+    x = jnp.maximum(peizer_pratt_root(z, lambda_), -0.4)
+
+    # each partial closes over the other variable, so jax treats it as a
+    # constant instead of carrying around a zero tangent
+    _, dz_lambda = jvp(lambda ell: peizer_pratt_z(x, ell), (lambda_,), (lambda_dot,))
+    _, dz_x = jvp(lambda x: peizer_pratt_z(x, lambda_), (x,), (jnp.ones_like(x),))
+
+    return sample, (z_dot - dz_lambda) / dz_x
+
+
+def poisson_cdf_inversion(
+    u: Float[Array, '*shape'], lambda_: Float[Array, '*shape']
+) -> Float[Array, '*shape']:
+    """Invert the cdf truncated to the first `NUM_TERMS` values."""
+    k = jnp.arange(NUM_TERMS, dtype=lambda_.dtype).reshape(
+        (NUM_TERMS, *lambda_.ndim * (1,))
+    )
+    logpmf = xlogy(k, lambda_) - lambda_ - gammaln(k + 1)
+    cdf = jnp.cumsum(jnp.exp(logpmf), axis=0)
+    # scale u by the top cdf value: this makes the comparison immune to the
+    # roundoff of the cdf normalization when u saturates to 1, and piles the
+    # truncated tail mass on the last value of the table
+    u *= cdf[-1, ...]
+    # the sum counts bools, which is exact in any dtype; produce it directly as
+    # float to match the other branch
+    return jnp.sum(cdf < u, axis=0, dtype=u.dtype)
+
+
+def poisson_peizer_pratt(
+    z: Float[Array, '*shape'], lambda_: Float[Array, '*shape']
+) -> Float[Array, '*shape']:
+    """Invert the Peizer-Pratt cdf approximation Pr[X <= x] ~ Phi(z(x)).
+
+    The sample is the smallest integer x with z(x) >= z, i.e., ceil of the real
+    root of z(x) = z. The exact z(x) is evaluated at 2 integers around an
+    analytical guess to select the right value, correcting the guess as long as
+    it falls within +/-1 of the root.
+    """
+    # the guess error stays within (-1 + 0.6, 1 + 0.6) of the root over
+    # theta >= THETA_SPLIT, |z| <= 8.4 (the float64 range of random.normal),
+    # so shifting by 0.6 centers it in the +/-1 window around ceil
+    x = peizer_pratt_root(z, lambda_) + 0.6
+
+    # select the smallest integer c with z(c) >= z among {c-1, c, c+1},
+    # c = ceil(x); z at negative integers is -inf since Pr[X <= x] = 0 there
+    c = jnp.ceil(x)
+
+    def zint(c: Float[Array, '*shape']) -> Float[Array, '*shape']:
+        return jnp.where(c < 0, -jnp.inf, peizer_pratt_z(jnp.maximum(c, 0.0), lambda_))
+
+    out = c + 1 - (zint(c) >= z) - (zint(c - 1) >= z)
+    return jnp.maximum(out, 0.0)
+
+
+def peizer_pratt_root(
+    z: Float[Array, '*shape'], lambda_: Float[Array, '*shape']
+) -> Float[Array, '*shape']:
+    """Cornish-Fisher approximation of the root of `peizer_pratt_z(x, .) = z`."""
+    s = jnp.sqrt(lambda_)
+    return (
+        lambda_ + s * z - 2 / 3 + jnp.square(z) / 6 + z * (1 - jnp.square(z)) / (72 * s)
+    )
+
+
+def peizer_pratt_z(
+    x: Float[Array, '*shape'], lambda_: Float[Array, '*shape']
+) -> Float[Array, '*shape']:
+    """Peizer-Pratt z(x) such that Pr[X <= x] ~ Phi(z(x)), for x > -1/2."""
+    y = (x + 0.5) / lambda_
+    t = peizer_pratt_t(y)
+    return (x - lambda_ + 2 / 3 + EPS / (x + 1)) * jnp.sqrt((1 + t) / lambda_)
+
+
+def peizer_pratt_t(y: Float[Array, '*shape']) -> Float[Array, '*shape']:
+    """T(y) = (1 - y^2 + 2 y log y) / (1 - y)^2, stable around y = 1."""
+    d = y - 1
+    small = jnp.abs(d) < 0.25
+
+    # series: T(1 + d) = sum_{k>=1} 2 (-1)^k d^k / ((k+1) (k+2)); 9 terms are
+    # the fewest that keep the truncation error at the cutoff (~2e-8) below
+    # float32 resolution; in float64 the Peizer-Pratt error dominates anyway
+    series = jnp.zeros_like(d)
+    for k in reversed(range(1, 10)):
+        coef = 2 * (-1) ** k / ((k + 1) * (k + 2))
+        series = d * (coef + series)
+
+    y_safe = jnp.where(small, 2.0, y)
+    d_safe = jnp.where(small, 1.0, d)
+    direct = (1 - jnp.square(y_safe) + 2 * y_safe * jnp.log(y_safe)) / jnp.square(
+        d_safe
+    )
+
+    return jnp.where(small, series, direct)

--- a/src/bartz/_jaxext/random/_poisson.py
+++ b/src/bartz/_jaxext/random/_poisson.py
@@ -29,7 +29,7 @@ from collections.abc import Sequence
 from jax import custom_jvp, jvp, random
 from jax import numpy as jnp
 from jax.dtypes import canonicalize_dtype
-from jax.scipy.special import gammaln, ndtr, xlogy
+from jax.scipy.special import ndtr
 from jax.typing import DTypeLike
 from jaxtyping import Array, Float, Integer, Key
 
@@ -158,18 +158,24 @@ def poisson_cdf_inversion(
     u: Float[Array, '*shape'], lambda_: Float[Array, '...']
 ) -> Float[Array, '*shape']:
     """Invert the cdf truncated to the first `NUM_TERMS` values."""
-    k = jnp.arange(NUM_TERMS, dtype=lambda_.dtype)
-
-    # this is normalized later, but keep it normalized anyway (lambda_ term)
-    # to avoid overflows in the intermediate jnp.exp(logpmf)
-    logpmf = xlogy(k, lambda_[..., None]) - lambda_[..., None] - gammaln(k + 1)
-
-    cdf = jnp.cumsum(jnp.exp(logpmf), axis=-1)
+    # unrolled pmf recurrence instead of cumsum(exp(logpmf(arange))): keeps
+    # every op elementwise at the broadcast shape, so xla fuses the inversion
+    # into one kernel instead of materializing shape x NUM_TERMS intermediates
+    pmf = jnp.exp(-lambda_)
+    cdf = pmf
+    cdfs = [cdf]
+    for k in range(1, NUM_TERMS):
+        pmf *= lambda_ / k
+        cdf += pmf
+        cdfs.append(cdf)
 
     # re-normalize because of truncation and float rounding
-    u *= cdf[..., -1]
+    u *= cdf
 
-    return jnp.sum(cdf < u[..., None], axis=-1).astype(u.dtype)
+    count = jnp.zeros_like(u)
+    for cdf in cdfs:
+        count += cdf < u
+    return count
 
 
 def poisson_peizer_pratt(

--- a/src/bartz/mcmcstep/_state.py
+++ b/src/bartz/mcmcstep/_state.py
@@ -1874,13 +1874,8 @@ def get_shard_map_patch_kwargs() -> ShardMapPatchKwargs:
     # bug: jax 0.8.1-0.8.2: vmap(shard_map(psum)), jax#34249; the
     # jax_disable_vmap_shmap_error config did not work.
 
-    # bug: jax 0.6.2: `random.poisson`'s internal `while_loop` (used by
-    # `sample_s_augmentation`) does not `pvary` its initial carry, so its
-    # output type varies over 'chains' while its input does not, whenever
-    # the rate argument does.
-
     # WORKAROUND(jax<=0.8.2): remove this whole function when jax > 0.8.2
-    buggy = ('0.8.1', '0.8.2', '0.6.2')
+    buggy = ('0.8.1', '0.8.2')
     if jax.__version__ in buggy:
         return {'check_vma': False}
     return {}

--- a/src/bartz/mcmcstep/_step.py
+++ b/src/bartz/mcmcstep/_step.py
@@ -44,7 +44,7 @@ from bartz._jaxext import (
     truncated_normal_onesided,
     vmap_nodoc,
 )
-from bartz._jaxext.random import loggamma
+from bartz._jaxext.random import loggamma, poisson
 from bartz.grove import var_histogram
 from bartz.mcmcstep._moves import Moves, propose_moves, split_range
 from bartz.mcmcstep._reduction import ReductionConfig
@@ -1927,7 +1927,7 @@ def sample_s_augmentation(key: Key[Array, ''], forest: Forest) -> Int32[Array, '
     # the per-node discarded-draw counts are negative-multinomial, with no
     # closed form when summed over nodes, but their Gamma-Poisson mixture does:
     # A_j | {lambda_b} ~ Poisson(s_j * blocked_mass[j]), independent across j
-    return random.poisson(keys.pop(), s * blocked_mass, dtype=jnp.int32)
+    return poisson(keys.pop(), s * blocked_mass, dtype=jnp.int32)
 
 
 @named_call

--- a/tests/test_jaxext.py
+++ b/tests/test_jaxext.py
@@ -31,7 +31,7 @@ from warnings import catch_warnings, simplefilter
 
 import numpy
 import pytest
-from jax import NamedSharding, device_put, jit, lax, make_mesh, random, shard_map, tree
+from jax import NamedSharding, device_put, jvp, lax, make_mesh, random, shard_map, tree
 
 # WORKAROUND(jax<0.7.1): top-level `jax.enable_x64` was added later; on older jax
 # it lives in `jax.experimental` (removed in newer jax). Use whichever exists.
@@ -44,9 +44,12 @@ from jax.sharding import AxisType, Mesh, PartitionSpec
 from jax.typing import DTypeLike
 from jaxtyping import Array, Float, Float32, Key, Shaped
 from pytest_subtests import SubTests
+from scipy.special import ndtr as scipy_ndtr
 from scipy.stats import anderson_ksamp, ks_1samp, truncnorm
 from scipy.stats import invgamma as scipy_invgamma
 from scipy.stats import loggamma as scipy_loggamma
+from scipy.stats import poisson as scipy_poisson
+from scipy.stats import uniform as scipy_uniform
 
 from bartz._jaxext import (
     autobatch,
@@ -54,13 +57,20 @@ from bartz._jaxext import (
     get_default_devices,
     get_device_count,
     is_key,
+    jit,
     split,
     truncated_normal_onesided,
     unique,
 )
-from bartz._jaxext.random import loggamma
+from bartz._jaxext.random import loggamma, poisson
+from bartz._jaxext.random._poisson import poisson_from_normal
 from bartz._jaxext.scipy.stats import invgamma
-from tests.util import assert_array_equal, assert_close_matrices, int_seed
+from tests.util import (
+    assert_allclose,
+    assert_array_equal,
+    assert_close_matrices,
+    int_seed,
+)
 
 
 class TestUnique:
@@ -605,6 +615,145 @@ class TestLoggamma:
         sample = loggamma(keys.pop(), alpha, (nsamples,), n_uniforms=n_uniforms)
         ks = ks_1samp(sample, scipy_loggamma(alpha).cdf)
         assert ks.pvalue > 1e-3
+
+
+@partial(jit, static_argnums=(2,))
+def _poisson_sample_and_tangent(
+    key: Key[Array, ''], lambda_: Float[Array, ''], nsamples: int
+) -> tuple[Float[Array, ' nsamples'], Float[Array, ' nsamples']]:
+    """Sample Poisson(lambda_) values and their derivative w.r.t. lambda_."""
+
+    def f(lambda_: Float[Array, '']) -> Float[Array, ' nsamples']:
+        return poisson(key, jnp.full((nsamples,), lambda_), dtype=float)
+
+    return jvp(f, (lambda_,), (jnp.ones_like(lambda_),))
+
+
+class TestPoisson:
+    """Test `_jaxext.random.poisson`."""
+
+    nsamples = 200_000  # the tests below pass unchanged up to 10M samples
+
+    @pytest.mark.parametrize('x64', [False, True])
+    @pytest.mark.parametrize('lambda_', [0.05, 0.5, 5.0, 7.0, 20.0, 1e3, 1e5])
+    def test_distribution(
+        self, keys: split, lambda_: float, x64: bool, subtests: SubTests
+    ) -> None:
+        """Check the samples follow Poisson(lambda_) against the cdf and a sample."""
+        nsamples = self.nsamples
+        ctx = enable_x64(True) if x64 else nullcontext()
+        with ctx:
+            sample = poisson(keys.pop(), lambda_, (nsamples,))
+            assert jnp.issubdtype(sample.dtype, jnp.integer)
+            assert jnp.all(sample >= 0)
+        sample = numpy.asarray(sample)
+
+        dist = scipy_poisson(lambda_)
+
+        # the plain KS test breaks on a discrete cdf, so map the sample to
+        # exactly uniform under H0 with the randomized probability integral
+        # transform: U = F(X - 1) + V pmf(X), V ~ uniform
+        with subtests.test('KS'):
+            rng = numpy.random.default_rng(int_seed(keys.pop()))
+            v = rng.uniform(size=sample.shape)
+            u = dist.cdf(sample - 1) + v * dist.pmf(sample)
+            ks = ks_1samp(u, scipy_uniform.cdf)
+            assert ks.pvalue > 1e-3
+
+        # the anderson-darling test is more sensitive in the tails; its midrank
+        # correction handles the heavily tied discrete samples
+        with subtests.test('AD'):
+            reference = dist.rvs(size=nsamples, random_state=int_seed(keys.pop()))
+            with catch_warnings():
+                # AD caps/floors its reported p-value to [0.001, 0.25], warning on it
+                simplefilter('ignore')
+                ad = anderson_ksamp([sample, reference])
+            # AD floors its p-value at 0.001, so we cut on the statistic instead
+            assert ad.statistic <= ad.critical_values[-1]  # 0.001 threshold
+
+    def test_zero(self, keys: split) -> None:
+        """Check lambda_ = 0 yields all zeros."""
+        sample = poisson(keys.pop(), 0.0, (self.nsamples,))
+        assert_array_equal(sample, jnp.zeros(sample.shape, sample.dtype))
+
+    @pytest.mark.parametrize('lambda_', [4.5, 8.5])
+    @pytest.mark.parametrize('shape', [(), (12,), (3, 4), (2, 3, 2), (1, 12, 1)])
+    def test_shape_consistency(
+        self, keys: split, lambda_: float, shape: tuple[int, ...]
+    ) -> None:
+        """A shaped draw equals the flat draw reshaped, given the same key."""
+        key = keys.pop()
+        sample = poisson(key, lambda_, shape)
+        assert sample.shape == shape
+        flat = poisson(random.clone(key), lambda_, (sample.size,))
+        assert_array_equal(sample.reshape(sample.size), flat)
+
+    @pytest.mark.parametrize('lambda_', [2.0, 5.0, 20.0, 1e3])
+    def test_derivative(self, keys: split, lambda_: float, subtests: SubTests) -> None:
+        """Averaged sample derivatives estimate derivatives of moments.
+
+        Single-sample derivatives of a discrete variable are meaningless; the
+        implicit-reparameterization tangent is defined to estimate derivatives
+        of expectations when averaged. Check the first two moments, whose
+        derivatives w.r.t. lambda_ are 1 and 2 lambda_ + 1. The 1% tolerance is
+        the tightest power of ten: it is set by the relaxation bias at
+        lambda_ = 2 (~ +0.6%), which does not shrink with more samples.
+        """
+        nsamples = self.nsamples
+        sample, tangent = _poisson_sample_and_tangent(keys.pop(), lambda_, nsamples)
+        assert jnp.all(jnp.isfinite(tangent))
+
+        with subtests.test('mean'):
+            assert_allclose(jnp.mean(tangent), 1.0, rtol=0.01)
+
+        with subtests.test('second moment'):
+            assert_allclose(jnp.mean(2 * sample * tangent), 2 * lambda_ + 1, rtol=0.01)
+
+    @pytest.mark.parametrize(
+        ('lambda_', 'bound'),
+        [
+            (0.1, 1e-6),
+            (1.0, 1e-6),
+            (5.0, 1e-5),
+            (6.9, 1e-5),
+            (7.0, 1e-4),
+            (10.0, 1e-4),
+            (20.0, 1e-5),
+            (50.0, 1e-5),
+        ],
+    )
+    def test_total_variation(self, lambda_: float, bound: float) -> None:
+        """Bound the exact total variation error of the sampler.
+
+        The sampler maps a normal variate monotonically to an integer, so its
+        implied pmf can be computed exactly (no sampling) by locating the jumps
+        of the map with bisection. The total variation distance to the true
+        Poisson pmf is dominated by float roundoff below the branch split and
+        by the Peizer-Pratt approximation error just above it; the bounds are
+        the observed values rounded up to a power of ten (or two).
+        """
+        num_values = int(scipy_poisson.isf(1e-12, lambda_)) + 3
+        k = jnp.arange(num_values, dtype=jnp.float32)
+        lambda_vec = jnp.full((num_values,), lambda_, jnp.float32)
+
+        # invariant: sampler(lo) <= k < sampler(hi), z jump locations in between
+        lo = jnp.full((num_values,), -7.0, jnp.float32)
+        hi = jnp.full((num_values,), 7.0, jnp.float32)
+        for _ in range(60):
+            mid = (lo + hi) / 2
+            below = poisson_from_normal(mid, lambda_vec) <= k
+            lo = jnp.where(below, mid, lo)
+            hi = jnp.where(below, hi, mid)
+
+        implied_cdf = scipy_ndtr(numpy.asarray(lo, numpy.float64))
+        implied_pmf = numpy.diff(numpy.concatenate([[0.0], implied_cdf]))
+        exact_pmf = scipy_poisson.pmf(numpy.arange(num_values), lambda_)
+
+        tv = 0.5 * numpy.abs(implied_pmf - exact_pmf).sum()
+        tv += 0.5 * abs(
+            (1 - implied_cdf[-1]) - scipy_poisson.sf(num_values - 1, lambda_)
+        )
+        assert tv < bound
 
 
 def test_is_key(keys: split) -> None:

--- a/tests/test_jaxext.py
+++ b/tests/test_jaxext.py
@@ -645,7 +645,9 @@ class TestPoisson:
     nsamples = 200_000  # the tests below pass unchanged up to 10M samples
 
     @pytest.mark.parametrize('x64', [False, True])
-    @pytest.mark.parametrize('lambda_', [0.05, 0.5, 5.0, 7.0, 20.0, 1e3, 1e5])
+    # 2**24 is the float32 integer limit: beyond it the samples land on the
+    # coarser float lattice, so it is the largest lambda_ with an exact pmf
+    @pytest.mark.parametrize('lambda_', [0.05, 0.5, 5.0, 7.0, 20.0, 1e3, 1e5, 2.0**24])
     def test_distribution(
         self, keys: split, lambda_: float, x64: bool, subtests: SubTests
     ) -> None:
@@ -729,7 +731,7 @@ class TestPoisson:
         with pytest.raises(ValueError, match='broadcast'):
             poisson(keys.pop(), jnp.ones(5), shape)
 
-    @pytest.mark.parametrize('lambda_', [2.0, 5.0, 20.0, 1e3])
+    @pytest.mark.parametrize('lambda_', [2.0, 5.0, 20.0, 1e3, 2.0**24])
     def test_derivative(self, keys: split, lambda_: float, subtests: SubTests) -> None:
         """Averaged sample derivatives estimate derivatives of moments.
 
@@ -744,11 +746,18 @@ class TestPoisson:
         sample, tangent = _poisson_sample_and_tangent(keys.pop(), lambda_, nsamples)
         assert jnp.all(jnp.isfinite(tangent))
 
+        # average in float64: at lambda_ = 2**24 the float32 reduction error
+        # on the second moment would be comparable to the 1% tolerance
+        sample = numpy.asarray(sample, numpy.float64)
+        tangent = numpy.asarray(tangent, numpy.float64)
+
         with subtests.test('mean'):
-            assert_allclose(jnp.mean(tangent), 1.0, rtol=0.01)
+            assert_allclose(numpy.mean(tangent), 1.0, rtol=0.01)
 
         with subtests.test('second moment'):
-            assert_allclose(jnp.mean(2 * sample * tangent), 2 * lambda_ + 1, rtol=0.01)
+            assert_allclose(
+                numpy.mean(2 * sample * tangent), 2 * lambda_ + 1, rtol=0.01
+            )
 
     @pytest.mark.parametrize(
         ('lambda_', 'bound'),
@@ -761,6 +770,8 @@ class TestPoisson:
             (10.0, 1e-4),
             (20.0, 1e-5),
             (50.0, 1e-5),
+            (1e6, 1e-4),
+            (1.6e7, 1e-4),  # just below 2**24, pmf not available above
         ],
     )
     def test_total_variation(self, lambda_: float, bound: float) -> None:
@@ -773,27 +784,30 @@ class TestPoisson:
         by the Peizer-Pratt approximation error just above it; the bounds are
         the observed values rounded up to a power of ten (or two).
         """
-        num_values = int(scipy_poisson.isf(1e-12, lambda_)) + 3
-        k = jnp.arange(num_values, dtype=jnp.float32)
-        lambda_vec = jnp.full((num_values,), lambda_, jnp.float32)
+        # enumerate a window covering all but ~1e-12 of both pmfs; k0 - 1 is
+        # included as the base of the cdf differences (never sampled, so its
+        # implied cdf bisects to ~0 when k0 = 0)
+        k0 = max(int(scipy_poisson.ppf(1e-12, lambda_)) - 2, 0)
+        k1 = int(scipy_poisson.isf(1e-12, lambda_)) + 2
+        k = k0 - 1 + jnp.arange(k1 - k0 + 2, dtype=jnp.float32)
 
         # invariant: sampler(lo) <= k < sampler(hi), z jump locations in between
-        lo = jnp.full((num_values,), -7.0, jnp.float32)
-        hi = jnp.full((num_values,), 7.0, jnp.float32)
+        lo = jnp.full(k.shape, -8.0, jnp.float32)
+        hi = jnp.full(k.shape, 8.0, jnp.float32)
         for _ in range(60):
             mid = (lo + hi) / 2
-            below = poisson_from_normal(mid, lambda_vec) <= k
+            below = poisson_from_normal(mid, jnp.float32(lambda_)) <= k
             lo = jnp.where(below, mid, lo)
             hi = jnp.where(below, hi, mid)
 
         implied_cdf = scipy_ndtr(numpy.asarray(lo, numpy.float64))
-        implied_pmf = numpy.diff(numpy.concatenate([[0.0], implied_cdf]))
-        exact_pmf = scipy_poisson.pmf(numpy.arange(num_values), lambda_)
+        implied_pmf = numpy.diff(implied_cdf)
+        exact_pmf = scipy_poisson.pmf(numpy.arange(k0, k1 + 1), lambda_)
 
         tv = 0.5 * numpy.abs(implied_pmf - exact_pmf).sum()
-        tv += 0.5 * abs(
-            (1 - implied_cdf[-1]) - scipy_poisson.sf(num_values - 1, lambda_)
-        )
+        # out-of-window mass of both pmfs bounds its TV contribution
+        tv += 0.5 * (implied_cdf[0] + scipy_poisson.cdf(k0 - 1, lambda_))
+        tv += 0.5 * ((1 - implied_cdf[-1]) + scipy_poisson.sf(k1, lambda_))
         assert tv < bound
 
 

--- a/tests/test_jaxext.py
+++ b/tests/test_jaxext.py
@@ -731,18 +731,20 @@ class TestPoisson:
         with pytest.raises(ValueError, match='broadcast'):
             poisson(keys.pop(), jnp.ones(5), shape)
 
-    @pytest.mark.parametrize('lambda_', [2.0, 5.0, 20.0, 1e3, 2.0**24])
+    @pytest.mark.parametrize('lambda_', [0.1, 0.5, 2.0, 5.0, 20.0, 1e3, 2.0**24])
     def test_derivative(self, keys: split, lambda_: float, subtests: SubTests) -> None:
         """Averaged sample derivatives estimate derivatives of moments.
 
         Single-sample derivatives of a discrete variable are meaningless; the
         implicit-reparameterization tangent is defined to estimate derivatives
         of expectations when averaged. Check the first two moments, whose
-        derivatives w.r.t. lambda_ are 1 and 2 lambda_ + 1. The 1% tolerance is
-        the tightest power of ten: it is set by the relaxation bias at
-        lambda_ = 2 (~ +0.6%), which does not shrink with more samples.
+        derivatives w.r.t. lambda_ are 1 and 2 lambda_ + 1; below the branch
+        split the estimates are exactly unbiased. The 1% tolerance is the
+        tightest power of ten: it is set by the sampling noise at the smallest
+        lambda_, where the tangent variance ~ 1/(3 lambda_) peaks.
         """
-        nsamples = self.nsamples
+        # more samples at small lambda_ to beat the 1/(3 lambda_) variance
+        nsamples = self.nsamples * (16 if lambda_ < 1 else 1)
         sample, tangent = _poisson_sample_and_tangent(keys.pop(), lambda_, nsamples)
         assert jnp.all(jnp.isfinite(tangent))
 

--- a/tests/test_jaxext.py
+++ b/tests/test_jaxext.py
@@ -31,7 +31,17 @@ from warnings import catch_warnings, simplefilter
 
 import numpy
 import pytest
-from jax import NamedSharding, device_put, jvp, lax, make_mesh, random, shard_map, tree
+from jax import (
+    NamedSharding,
+    device_put,
+    grad,
+    jvp,
+    lax,
+    make_mesh,
+    random,
+    shard_map,
+    tree,
+)
 
 # WORKAROUND(jax<0.7.1): top-level `jax.enable_x64` was added later; on older jax
 # it lives in `jax.experimental` (removed in newer jax). Use whichever exists.
@@ -687,6 +697,37 @@ class TestPoisson:
         assert sample.shape == shape
         flat = poisson(random.clone(key), lambda_, (sample.size,))
         assert_array_equal(sample.reshape(sample.size), flat)
+
+    @pytest.mark.parametrize('lambda_', [4.5, 8.5])
+    @pytest.mark.parametrize('lambda_shape', [(), (4,), (1, 4)])
+    def test_lambda_broadcast(
+        self, keys: split, lambda_: float, lambda_shape: tuple[int, ...]
+    ) -> None:
+        """A draw with unbroadcasted lambda_ equals the pre-broadcasted draw."""
+        shape = (3, 4)
+        key = keys.pop()
+        sample = poisson(key, jnp.full(lambda_shape, lambda_), shape)
+        assert sample.shape == shape
+        expected = poisson(random.clone(key), jnp.full(shape, lambda_), shape)
+        assert_array_equal(sample, expected)
+
+    def test_lambda_broadcast_grad(self, keys: split) -> None:
+        """Reverse mode w.r.t. an unbroadcasted lambda_ sums over the broadcast."""
+        lambda_ = jnp.array([2.0, 20.0])
+        key = keys.pop()
+
+        def f(lambda_: Float[Array, ' 2']) -> Float[Array, '5 2']:
+            return poisson(key, lambda_, (5, 2), dtype=float)
+
+        _, tangent = jvp(f, (lambda_,), (jnp.ones_like(lambda_),))
+        gradient = grad(lambda lambda_: f(lambda_).sum())(lambda_)
+        assert_close_matrices(gradient, tangent.sum(axis=0), rtol=1e-6)
+
+    @pytest.mark.parametrize('shape', [(3,), ()])
+    def test_lambda_shape_mismatch(self, keys: split, shape: tuple[int, ...]) -> None:
+        """A lambda_ that does not broadcast to shape is an error."""
+        with pytest.raises(ValueError, match='broadcast'):
+            poisson(keys.pop(), jnp.ones(5), shape)
 
     @pytest.mark.parametrize('lambda_', [2.0, 5.0, 20.0, 1e3])
     def test_derivative(self, keys: split, lambda_: float, subtests: SubTests) -> None:


### PR DESCRIPTION
This PR speeds up the s-augmentation MCMC step by replacing `jax.random.poisson` with a custom loop-free approximate sampler, `bartz._jaxext.random.poisson`. jax's sampler compiles to rejection while loops whose trip count is the worst element in the batch; the new one maps a single standard normal per element through either direct inversion of the truncated cdf (λ < 7) or inversion of the Peizer–Pratt normal approximation (λ ≥ 7). Everything is elementwise, so XLA fuses the whole sampler into one kernel with zero temporary buffers. The approximation error is below 1e-4 in total variation, worst around λ = 7, and the samples carry an approximate derivative w.r.t. λ via implicit differentiation of the Peizer–Pratt relaxation.

Throughput vs `jax.random.poisson` (jitted, time per call, elementwise λ log-uniform in [0.1, 100]; RTX 3060 / 4-core CPU, jax 0.10.2):

| backend, size | jax → bartz |
|---|---|
| GPU 10⁶ | 4.6 → 0.16 ms (28×) |
| GPU 10⁷ | 37 → 1.0 ms (36×) |
| GPU 10⁸ | 408 → 10 ms (40×) |
| CPU 10⁵ | 39 → 1.2 ms (34×) |
| CPU 10⁶ | 791 → 14 ms (58×) |
| CPU 10⁷ | 8.6 → 0.32 s (27×) |

Scalar λ gives similar speedups (e.g. 38× at GPU 10⁸, λ=7). Small-shape latency, the regime relevant to the MCMC step, improves ~100× on GPU (167 → 1.7 µs per call at scalar shape), landing within ~1 µs of the cost of just drawing the underlying normals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)