### PR TITLE
perf(mcmcstep): stop copying leaf_indices in step

### DIFF
--- a/benchmarks/speed.py
+++ b/benchmarks/speed.py
@@ -24,6 +24,7 @@
 
 """Measure the speed of the MCMC and its interfaces."""
 
+import math
 import sys
 from collections.abc import Callable, Mapping
 from contextlib import redirect_stderr, redirect_stdout
@@ -279,7 +280,11 @@ class AutoParamNames:
     def __init_subclass__(cls, **_: Any) -> None:
         method = cls.setup
         sig = signature(method)
-        params = list(sig.parameters)
+        params = [
+            name
+            for name, param in sig.parameters.items()
+            if param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)
+        ]
         assert params[0] == 'self'
         cls.param_names = tuple(params[1:])
 
@@ -511,10 +516,14 @@ class StepMemory(StepBase):
             kwargs.setdefault('filter_splitless_vars', 0)
         return eval_shape(lambda: simple_init(**kwargs))
 
-    def setup(self, kind: Kind, chains: int | None, stat: MemStat) -> None:  # ty:ignore[invalid-method-override]
+    def setup(  # ty:ignore[invalid-method-override]
+        self, kind: Kind, chains: int | None, stat: MemStat, **kwargs: Any
+    ) -> None:
         """Compile `step` at large scale and extract its memory analysis."""
         # n=16Mi, num_trees=p=1Ki, abstract eval so may exceed device memory
-        super().setup('compile', kind, chains, n=16 * 2**20, num_trees=1024, p=1024)
+        super().setup(
+            'compile', kind, chains, n=16 * 2**20, num_trees=1024, p=1024, **kwargs
+        )
         analysis = self.compiled_func.memory_analysis()
         if analysis is None:
             # the active backend does not expose a memory analysis
@@ -528,6 +537,51 @@ class StepMemory(StepBase):
         return self.memory[self.stat]
 
     track_memory.unit = 'bytes'  # ty: ignore[unresolved-attribute]
+
+
+Shards = int | None
+
+
+class StepMemorySharded(StepMemory):
+    """Per-device memory footprint of `mcmcstep.step` on a sharded state.
+
+    Same abstract-scale analysis as `StepMemory`, on a state sharded over a
+    device mesh. `data_shards` and `chain_shards` set the sizes of the 'data'
+    and 'chains' mesh axes; `None` leaves an axis out of the mesh. The state
+    is single-chain when `chain_shards` is None and 2 chains otherwise, so a
+    size-1 mesh axis isolates the overhead of the sharding machinery from the
+    memory scaling, and the no-mesh corner matches `StepMemory`. The
+    per-device statistics are rescaled by the mesh size to report the total
+    over all devices: ideally sharding leaves the total unchanged, and
+    replicated buffers show up as excess over the unsharded case.
+    """
+
+    params: tuple[tuple[Shards, ...], tuple[Shards, ...], tuple[MemStat, ...]] = (
+        (None, 1, 2),
+        (None, 1, 2),
+        ('state', 'peak'),
+    )
+
+    def setup(  # ty:ignore[invalid-method-override]
+        self, data_shards: Shards, chain_shards: Shards, stat: MemStat
+    ) -> None:
+        """Compile `step` on a sharded state and extract its memory analysis."""
+        mesh = {}
+        if chain_shards is not None:
+            mesh['chains'] = chain_shards
+        if data_shards is not None:
+            mesh['data'] = data_shards
+
+        num_devices = math.prod(mesh.values())
+        if get_device_count() < num_devices:
+            msg = (
+                f'{num_devices} devices needed to shard, {get_device_count()} available'
+            )
+            raise NotImplementedError(msg)
+
+        chains = None if chain_shards is None else 2
+        super().setup('plain', chains, stat, mesh=mesh or None)
+        self.memory = {k: v * num_devices for k, v in self.memory.items()}
 
 
 class BaseGbart(AutoParamNames):

--- a/src/bartz/_jaxext/__init__.py
+++ b/src/bartz/_jaxext/__init__.py
@@ -37,6 +37,7 @@ from bartz._jaxext._jaxext import (
     jaxtyping_disabled,
     jit_active,
     minimal_unsigned_dtype,
+    sliced_map,
     split,
     truncated_normal_onesided,
     unique,

--- a/src/bartz/_jaxext/_jaxext.py
+++ b/src/bartz/_jaxext/_jaxext.py
@@ -90,6 +90,65 @@ def vmap_nodoc(fun: Callable, *args: Any, **kw: Any) -> Callable:
     return fun
 
 
+def sliced_map(
+    f: Callable[[PyTree[Array, ' I']], PyTree[Array, ' O']],
+    xs: PyTree[Array, ' I'],
+    *,
+    batch_size: int,
+) -> PyTree[Array, ' O']:
+    """
+    Like `jax.lax.map` with `batch_size`, but read `xs` by slicing.
+
+    The scan body slices each batch out of the closed-over `xs` with
+    `lax.dynamic_slice_in_dim` instead of consuming `xs` reshaped into scan xs.
+    Under `vmap`, the batching rule for values closed over by a scan moves the
+    batch axes to the front, so leading batch axes in the leaves of `xs` are
+    consumed in place, while `lax.map` would transpose them to sit after the
+    scanned and `batch_size` axes.
+
+    Parameters
+    ----------
+    f
+        The function to apply elementwise, taking and returning pytrees of
+        arrays.
+    xs
+        A pytree of arrays to map over along their first axes.
+    batch_size
+        The number of elements to process at a time, vectorized. The remainder
+        of the division of the number of elements by `batch_size` is processed
+        as one additional smaller batch.
+
+    Returns
+    -------
+    A pytree of stacked outputs of `f`, like `jax.lax.map`.
+    """
+    (num_el,) = {x.shape[0] for x in tree.leaves(xs)}
+
+    # shortcut if no batching needed
+    if batch_size >= num_el:
+        return vmap(f)(xs)
+
+    num_batches, remainder = divmod(num_el, batch_size)
+
+    def apply_batch(start: Integer[Array, ''] | int, size: int) -> PyTree[Array, ' O']:
+        def slice_batch(
+            x: Shaped[Array, ' num_el *shape'],
+        ) -> Shaped[Array, ' size *shape']:
+            return lax.dynamic_slice_in_dim(x, start, size, axis=0)
+
+        return vmap(f)(tree.map(slice_batch, xs))
+
+    def loop(_: None, start: Integer[Array, '']) -> tuple[None, PyTree[Array, ' O']]:
+        return None, apply_batch(start, batch_size)
+
+    _, out = lax.scan(loop, None, batch_size * jnp.arange(num_batches))
+    out = tree.map(lambda x: x.reshape(num_batches * batch_size, *x.shape[2:]), out)
+    if remainder:
+        rest = apply_batch(num_batches * batch_size, remainder)
+        out = tree.map(lambda x, y: jnp.concatenate([x, y], axis=0), out, rest)
+    return out
+
+
 def minimal_unsigned_dtype(value: int) -> DTypeLike:
     """Return the smallest unsigned integer dtype that can represent `value`."""
     if value < 2**8:

--- a/src/bartz/mcmcstep/_state.py
+++ b/src/bartz/mcmcstep/_state.py
@@ -240,12 +240,27 @@ class Forest(Module):
     leaf_indices: UInt[Array, 'num_trees *chains n'] = field(
         chains=CHAIN_AXIS_AFTER_TREES, data=-1
     )
-    """The index of the leaf each datapoint falls into, for each tree.
+    """The index of the leaf each datapoint falls into, for each tree, in the
+    largest version of the tree compatible with the last moves.
+
+    A pending prune (accepted prune or rejected grow, marked per-tree by
+    `to_prune`) is not yet applied to the indices; `step` folds it in at the
+    beginning of the next iteration. Evaluating the trees at these indices is
+    correct anyway because `leaf_tree` mirrors the value of a pruned node onto
+    its dangling children.
 
     The chain axis sits after `num_trees` (not leading, unlike sibling fields)
     so the per-tree `jax.lax.scan` in `step`, under the chain `jax.vmap`,
     avoids a transpose of this large array that otherwise inflates gpu peak
     memory."""
+
+    to_prune: Bool[Array, '*chains num_trees'] = field(chains=CHAIN_AXIS)
+    """Whether the last move on each tree ended in a prune (accepted prune or
+    rejected grow) whose application to `leaf_indices` is still pending."""
+
+    move_node: Int32[Array, '*chains num_trees'] = field(chains=CHAIN_AXIS)
+    """The node the last move on each tree operated on (the leaf to grow or
+    the node to prune). Meaningful only where `to_prune` is set."""
 
     count_tree: UInt32[Array, '*chains num_trees 2*half_tree_size'] | None = field(
         chains=CHAIN_AXIS
@@ -1068,6 +1083,10 @@ def init(
                 leaf_indices=lazy(
                     jnp.ones, (num_trees, n), minimal_unsigned_dtype(tree_size - 1)
                 ),
+                # no pending prune: `step` starts by applying the pending
+                # prunes to `leaf_indices`, which shall be a no-op on init
+                to_prune=lazy(jnp.zeros, (num_trees,), bool),
+                move_node=lazy(jnp.zeros, (num_trees,), jnp.int32),
                 # the counts serve the minimum-points constraints and stand in
                 # for the precisions when there are no per-datapoint scales
                 # (`prec_scale` is set iff `error_scale` or `missing` is given)

--- a/src/bartz/mcmcstep/_state.py
+++ b/src/bartz/mcmcstep/_state.py
@@ -74,8 +74,6 @@ ArrayLike = Array | ndarray
 
 FloatLike = float | Float[ArrayLike, '']
 
-CHAIN_AXIS_AFTER_TREES = {0: 1, -1: -1}[CHAIN_AXIS]
-
 
 class OutcomeType(Enum):
     """Likelihood types for each outcome component in the regression."""
@@ -237,9 +235,7 @@ class Forest(Module):
     p_propose_grow: Float32[Array, ' half_tree_size']
     """The unnormalized probability of picking a leaf for a grow proposal."""
 
-    leaf_indices: UInt[Array, 'num_trees *chains n'] = field(
-        chains=CHAIN_AXIS_AFTER_TREES, data=-1
-    )
+    leaf_indices: UInt[Array, '*chains num_trees n'] = field(chains=CHAIN_AXIS, data=-1)
     """The index of the leaf each datapoint falls into, for each tree, in the
     largest version of the tree compatible with the last moves.
 
@@ -247,12 +243,7 @@ class Forest(Module):
     `to_prune`) is not yet applied to the indices; `step` folds it in at the
     beginning of the next iteration. Evaluating the trees at these indices is
     correct anyway because `leaf_tree` mirrors the value of a pruned node onto
-    its dangling children.
-
-    The chain axis sits after `num_trees` (not leading, unlike sibling fields)
-    so the per-tree `jax.lax.scan` in `step`, under the chain `jax.vmap`,
-    avoids a transpose of this large array that otherwise inflates gpu peak
-    memory."""
+    its dangling children."""
 
     to_prune: Bool[Array, '*chains num_trees'] = field(chains=CHAIN_AXIS)
     """Whether the last move on each tree ended in a prune (accepted prune or

--- a/src/bartz/mcmcstep/_step.py
+++ b/src/bartz/mcmcstep/_step.py
@@ -40,6 +40,7 @@ from bartz._jaxext import (
     Module,
     field,
     jit,
+    minimal_unsigned_dtype,
     split,
     truncated_normal_onesided,
     vmap_nodoc,
@@ -1092,6 +1093,7 @@ def accept_moves_sequential_stage(pso: ParallelStageOut) -> tuple[State, Moves]:
             resid,
             SeqStageInAllTrees(
                 pso.state.X,
+                pso.state.forest.leaf_indices,
                 pso.state.config.resid_reduction_config,
                 pso.state.config.data_sharded,
                 pso.state.prec_scale,
@@ -1108,11 +1110,12 @@ def accept_moves_sequential_stage(pso: ParallelStageOut) -> tuple[State, Moves]:
         )
         return resid, (leaf_tree, acc, to_prune, lkratio)
 
+    num_trees, _ = pso.state.forest.leaf_indices.shape
     pts = SeqStageInPerTree(
         pso.state.forest.leaf_tree,
         pso.prec_trees,
         pso.moves,
-        pso.state.forest.leaf_indices,
+        jnp.arange(num_trees, dtype=minimal_unsigned_dtype(num_trees - 1)),
         pso.prelkv,
         pso.prelf,
     )
@@ -1135,6 +1138,14 @@ class SeqStageInAllTrees(Module):
 
     X: UInt[Array, 'p n']
     """The predictors."""
+
+    leaf_indices: UInt[Array, 'num_trees n']
+    """The leaf indices for the largest version of each tree compatible with
+    the move. Kept whole here and sliced per tree with
+    `SeqStageInPerTree.tree_index`, instead of consumed as scan xs, because
+    the scan batching rules move the chain axis of closed-over values to the
+    front, matching the storage layout, while the xs rule would transpose it
+    to after the tree axis."""
 
     resid_reduction_config: ReductionConfig
     """How to sum the residuals in each leaf."""
@@ -1191,9 +1202,8 @@ class SeqStageInPerTree(Module):
     move: Moves
     """The proposed move, see `propose_moves`."""
 
-    leaf_indices: UInt[Array, 'num_trees n']
-    """The leaf indices for the largest version of the tree compatible with
-    the move."""
+    tree_index: UInt[Array, ' num_trees']
+    """The index of the tree, used to slice `SeqStageInAllTrees.leaf_indices`."""
 
     prelkv: PreLkV
     """The pre-computed terms of the likelihood ratio which are specific to the tree."""
@@ -1244,6 +1254,8 @@ def accept_move_and_sample_leaves(
         The logarithm of the likelihood ratio for the move. `None` if not to be
         saved.
     """
+    leaf_indices = at.leaf_indices[pt.tree_index, :]
+
     # sum residuals in each leaf, in tree proposed by grow move
     if at.prec_scale is None:
         scaled_resid = resid
@@ -1254,7 +1266,7 @@ def accept_move_and_sample_leaves(
 
     resid_tree = sum_resid(
         scaled_resid,
-        pt.leaf_indices,
+        leaf_indices,
         tree_size,
         at.resid_reduction_config,
         at.data_sharded,
@@ -1341,7 +1353,7 @@ def accept_move_and_sample_leaves(
     # scatter, so the n-sized update stays in the narrow `resid` storage
     leaf_delta = prev_leaf_tree - at.leaf_unit[..., None] * leaf_tree
     delta = (leaf_delta / at.resid_unit[..., None]).astype(resid.dtype)
-    resid += delta[..., pt.leaf_indices]
+    resid += delta[..., leaf_indices]
 
     return resid, leaf_tree, acc, to_prune, log_lk_ratio
 

--- a/src/bartz/mcmcstep/_step.py
+++ b/src/bartz/mcmcstep/_step.py
@@ -351,15 +351,18 @@ def accept_moves_parallel_stage(
     -------
     An object with all that could be done in parallel.
     """
-    # where the move is grow, modify the state like the move was accepted
+    # apply the prunes pending from the previous step to the leaf indices,
+    # then, where the new move is grow, modify the state like the move was
+    # accepted.
+    leaf_indices = apply_moves_to_leaf_indices(
+        state.forest.leaf_indices, state.forest.to_prune, state.forest.move_node
+    )
     state = replace(
         state,
         forest=replace(
             state.forest,
             var_tree=moves.var_tree,
-            leaf_indices=apply_grow_to_indices(
-                moves, state.forest.leaf_indices, state.X
-            ),
+            leaf_indices=apply_grow_to_indices(moves, leaf_indices, state.X),
             leaf_tree=adapt_leaf_trees_to_grow_indices(state.forest.leaf_tree, moves),
         ),
     )
@@ -454,7 +457,8 @@ def apply_grow_to_indices(
     moves
         The proposed moves, see `propose_moves`.
     leaf_indices
-        The index of the leaf each datapoint falls into.
+        The index of the leaf each datapoint falls into, with the prunes
+        pending from the previous step already applied.
     X
         The predictors matrix.
 
@@ -1285,7 +1289,9 @@ def accept_move_and_sample_leaves(
     leaf_tree = mean_post + pt.prelf.centered_leaves
 
     # copy leaves around such that the leaf indices point to the correct leaf;
-    # the parent slot is written back unchanged to share a single scatter
+    # the parent slot is written back unchanged to share a single scatter.
+    # this mirroring persists into the output state, where it keeps the
+    # not-yet-pruned `leaf_indices` valid to evaluate the trees
     to_prune = acc ^ pt.move.grow
     leaf_tree = leaf_tree.at[
         ..., jnp.where(to_prune, pt.move.lrt_nodes, tree_size)
@@ -1436,6 +1442,10 @@ def accept_moves_final_stage(state: State, moves: Moves) -> State:
     This function is separate from `accept_moves_sequential_stage` to signal it
     can work in parallel across trees.
 
+    The prunes are not applied to `bartz.mcmcstep.Forest.leaf_indices` here;
+    they are recorded in `to_prune`/`move_node` and applied at the beginning of
+    the next step.
+
     Parameters
     ----------
     state
@@ -1449,13 +1459,15 @@ def accept_moves_final_stage(state: State, moves: Moves) -> State:
     The fully updated BART mcmc state.
     """
     assert moves.acc is not None
+    assert moves.to_prune is not None
     return replace(
         state,
         forest=replace(
             state.forest,
             grow_acc_count=jnp.sum(moves.acc & moves.grow),
             prune_acc_count=jnp.sum(moves.acc & ~moves.grow),
-            leaf_indices=apply_moves_to_leaf_indices(state.forest.leaf_indices, moves),
+            to_prune=moves.to_prune,
+            move_node=moves.lrt_nodes[..., 2],
             split_tree=apply_moves_to_split_trees(state.forest.split_tree, moves),
             affluence_tree=apply_moves_to_affluence_trees(
                 state.forest.affluence_tree, moves
@@ -1466,39 +1478,42 @@ def accept_moves_final_stage(state: State, moves: Moves) -> State:
 
 @named_call
 def apply_moves_to_leaf_indices(
-    leaf_indices: UInt[Array, 'num_trees n'], moves: Moves
+    leaf_indices: UInt[Array, 'num_trees n'],
+    to_prune: Bool[Array, ' num_trees'],
+    move_node: Int32[Array, ' num_trees'],
 ) -> UInt[Array, 'num_trees n']:
     """
-    Update the leaf indices to match the accepted move.
+    Apply the prunes pending from the previous step to the leaf indices.
 
     Parameters
     ----------
     leaf_indices
-        The index of the leaf each datapoint falls into, if the grow move was
-        accepted.
-    moves
-        The proposed moves (see `propose_moves`), as updated by
-        `accept_moves_sequential_stage`.
+        The index of the leaf each datapoint falls into, in the largest version
+        of each tree compatible with the last moves (see
+        `Forest.leaf_indices`).
+    to_prune
+        Whether the last move on each tree ended in a prune yet to be applied.
+    move_node
+        The node the last move on each tree operated on.
 
     Returns
     -------
     The updated leaf indices.
     """
-    return _apply_moves_to_leaf_indices(leaf_indices, moves)
+    return _apply_moves_to_leaf_indices(leaf_indices, to_prune, move_node)
 
 
 @vmap_nodoc
 def _apply_moves_to_leaf_indices(
-    leaf_indices: UInt[Array, ' n'], moves: Moves
+    leaf_indices: UInt[Array, ' n'],
+    to_prune: Bool[Array, ''],
+    move_node: Int32[Array, ''],
 ) -> UInt[Array, ' n']:
     """Implement `apply_moves_to_leaf_indices`."""
     mask = ~jnp.array(1, leaf_indices.dtype)  # ...1111111110
-    is_child = (leaf_indices & mask) == moves.lrt_nodes[0]
-    assert moves.to_prune is not None
+    is_child = (leaf_indices & mask) == (move_node << 1)
     return jnp.where(
-        is_child & moves.to_prune,
-        moves.lrt_nodes[2].astype(leaf_indices.dtype),
-        leaf_indices,
+        is_child & to_prune, move_node.astype(leaf_indices.dtype), leaf_indices
     )
 
 

--- a/src/bartz/mcmcstep/_step.py
+++ b/src/bartz/mcmcstep/_step.py
@@ -41,6 +41,7 @@ from bartz._jaxext import (
     field,
     jit,
     minimal_unsigned_dtype,
+    sliced_map,
     split,
     truncated_normal_onesided,
     vmap_nodoc,
@@ -545,6 +546,8 @@ def _compute_count_or_prec_trees(
     if config.prec_count_num_trees is None:
         return all_trees()
 
+    batch_size = config.prec_count_num_trees
+
     def compute(
         args: tuple[
             UInt32[Array, ' tree_size']
@@ -568,15 +571,13 @@ def _compute_count_or_prec_trees(
         | tuple[Float32[Array, 'num_trees tree_size'], None]
         | tuple[Float32[Array, 'num_trees k k tree_size'], None]
     ):
-        return lax.map(
-            compute,
-            (trees, leaf_indices, moves),
-            batch_size=config.prec_count_num_trees,
-        )
+        # sliced_map instead of lax.map because under the chain vmap lax.map's
+        # reshape of the tree axis becomes a transpose of `leaf_indices` that
+        # xla materializes in full (cf. `SeqStageInAllTrees.leaf_indices`)
+        return sliced_map(compute, (trees, leaf_indices, moves), batch_size=batch_size)
 
     # the tree batching bounds the reduction temporaries on cpu; on gpu those
-    # fuse anyway, while under the chain vmap lax.map's reshape of the tree
-    # axis becomes a transpose of `leaf_indices` that xla materializes in full
+    # fuse anyway
     return lax.platform_dependent(cpu=tree_batches, cuda=all_trees)
 
 

--- a/src/bartz/mcmcstep/_step.py
+++ b/src/bartz/mcmcstep/_step.py
@@ -532,9 +532,17 @@ def _compute_count_or_prec_trees(
     | tuple[Float32[Array, 'num_trees k k tree_size'], None]
 ):
     """Implement `compute_count_trees` and `compute_prec_trees`."""
-    if config.prec_count_num_trees is None:
+
+    def all_trees() -> (
+        tuple[UInt32[Array, 'num_trees tree_size'], Counts]
+        | tuple[Float32[Array, 'num_trees tree_size'], None]
+        | tuple[Float32[Array, 'num_trees k k tree_size'], None]
+    ):
         compute = vmap(_compute_count_or_prec_tree, in_axes=(None, 0, 0, 0, None))
         return compute(prec_scale, trees, leaf_indices, moves, config)
+
+    if config.prec_count_num_trees is None:
+        return all_trees()
 
     def compute(
         args: tuple[
@@ -554,9 +562,21 @@ def _compute_count_or_prec_trees(
             prec_scale, tree, leaf_indices, moves, config
         )
 
-    return lax.map(
-        compute, (trees, leaf_indices, moves), batch_size=config.prec_count_num_trees
-    )
+    def tree_batches() -> (
+        tuple[UInt32[Array, 'num_trees tree_size'], Counts]
+        | tuple[Float32[Array, 'num_trees tree_size'], None]
+        | tuple[Float32[Array, 'num_trees k k tree_size'], None]
+    ):
+        return lax.map(
+            compute,
+            (trees, leaf_indices, moves),
+            batch_size=config.prec_count_num_trees,
+        )
+
+    # the tree batching bounds the reduction temporaries on cpu; on gpu those
+    # fuse anyway, while under the chain vmap lax.map's reshape of the tree
+    # axis becomes a transpose of `leaf_indices` that xla materializes in full
+    return lax.platform_dependent(cpu=tree_batches, cuda=all_trees)
 
 
 def _compute_count_or_prec_tree(

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -121,6 +121,7 @@ from bartz.mcmcloop._callback import _TQDM_REGISTRY
 from bartz.mcmcloop._loop import _inner_loop_counter
 from bartz.mcmcstep import BatchedReduction, State, step
 from bartz.mcmcstep._axes import chain_to_axis, chain_vmap_axes
+from bartz.mcmcstep._step import apply_moves_to_leaf_indices
 from bartz.prepcovars import GivenSplitsBinner, RangeEvenBinner, UniqueQuantileBinner
 from bartz.testing import DiscreteUniform, Gamma, gen_data
 from tests.test_mcmcstep import (
@@ -1932,6 +1933,11 @@ def test_count_prec_tree_caches_valid(bkw: BartKW, subtests: SubTests) -> None:
     leaf_indices = chain_to_axis(
         forest.leaf_indices, chain_vmap_axes(forest).leaf_indices
     ).reshape(-1, n)
+    # apply the prunes left pending by the last step, so the indices point to
+    # the actual leaves
+    leaf_indices = apply_moves_to_leaf_indices(
+        leaf_indices, forest.to_prune.reshape(-1), forest.move_node.reshape(-1)
+    )
 
     # mask of the actual leaves over the full heap, per tree
     leaf_mask = vmap(partial(is_actual_leaf, add_bottom_level=True))(split_tree)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1924,9 +1924,7 @@ def test_count_prec_tree_caches_valid(bkw: BartKW, subtests: SubTests) -> None:
         )
         assert (forest.prec_tree is not None) == (state.prec_scale is not None)
 
-    # flatten the chain axis (if any) into the tree axis. `leaf_indices` carries
-    # its chain axis after the tree axis (unlike `split_tree`), so move it to the
-    # front first, to match `split_tree`'s chain-leading flattening order
+    # flatten the chain axis (if any) into the tree axis
     _, n = state.X.shape
     half = forest.split_tree.shape[-1]
     split_tree = forest.split_tree.reshape(-1, half)

--- a/tests/test_jaxext.py
+++ b/tests/test_jaxext.py
@@ -31,7 +31,17 @@ from warnings import catch_warnings, simplefilter
 
 import numpy
 import pytest
-from jax import NamedSharding, device_put, jit, lax, make_mesh, random, shard_map, tree
+from jax import (
+    NamedSharding,
+    device_put,
+    jit,
+    lax,
+    make_mesh,
+    random,
+    shard_map,
+    tree,
+    vmap,
+)
 
 # WORKAROUND(jax<0.7.1): top-level `jax.enable_x64` was added later; on older jax
 # it lives in `jax.experimental` (removed in newer jax). Use whichever exists.
@@ -54,6 +64,7 @@ from bartz._jaxext import (
     get_default_devices,
     get_device_count,
     is_key,
+    sliced_map,
     split,
     truncated_normal_onesided,
     unique,
@@ -374,6 +385,62 @@ class TestAutoBatch:
         match = 'Expected None|different types at key path'
         with pytest.raises(ValueError, match=match):
             autobatch(func, 32, 0, None)(x)
+
+
+class TestSlicedMap:
+    """Test _jaxext.sliced_map."""
+
+    @staticmethod
+    def f(
+        args: tuple[Float[Array, ''], dict[str, Float[Array, ' m']]],
+    ) -> tuple[Float[Array, ''], tuple[Float[Array, ''], None]]:
+        """Do something; example first argument for `lax.map`."""
+        x, d = args
+        return x * d['w'].sum(), (x + 1, None)
+
+    def xs(
+        self, key: Key[Array, ''], shape: tuple[int, ...] = (10,)
+    ) -> tuple[Float[Array, '*batch n'], dict[str, Float[Array, '*batch n m']]]:
+        """Return example second argument for `lax.map`."""
+        keys = split(key)
+        x = random.uniform(keys.pop(), shape)
+        w = random.uniform(keys.pop(), (*shape, 3))
+        return x, dict(w=w)
+
+    @pytest.mark.parametrize('batch_size', [1, 3, 5, 10, 12])
+    # 3: remainder batch, 5: exact division, 10 and 12: single-batch shortcut
+    def test_matches_lax_map(self, keys: split, batch_size: int) -> None:
+        """Check the output is identical to `lax.map` with `batch_size`."""
+        xs = self.xs(keys.pop())
+        out = sliced_map(self.f, xs, batch_size=batch_size)
+        expected = lax.map(self.f, xs, batch_size=batch_size)
+        assert out[1][1] is None
+        tree.map(assert_array_equal, out, expected)
+
+    @pytest.mark.parametrize('batch_size', [3, 5])
+    def test_under_vmap(self, keys: split, batch_size: int) -> None:
+        """Check consistency with `lax.map` when the inputs are closed-over batched values."""
+        x, d = self.xs(keys.pop(), (2, 10))
+
+        def with_sliced_map(
+            x: Float[Array, ' n'], w: Float[Array, 'n m']
+        ) -> tuple[Float[Array, ' n'], tuple[Float[Array, ' n'], None]]:
+            return sliced_map(self.f, (x, dict(w=w)), batch_size=batch_size)
+
+        def with_lax_map(
+            x: Float[Array, ' n'], w: Float[Array, 'n m']
+        ) -> tuple[Float[Array, ' n'], tuple[Float[Array, ' n'], None]]:
+            return lax.map(self.f, (x, dict(w=w)), batch_size=batch_size)
+
+        out = vmap(with_sliced_map)(x, d['w'])
+        expected = vmap(with_lax_map)(x, d['w'])
+        tree.map(assert_array_equal, out, expected)
+
+    def test_mismatched_leading_axes(self, keys: split) -> None:
+        """Check that leaves with different leading axis sizes are an error."""
+        x, d = self.xs(keys.pop())
+        with pytest.raises(ValueError, match='values to unpack'):
+            sliced_map(self.f, (x[:5], d), batch_size=3)
 
 
 def different_keys(keya: Key[Array, ''], keyb: Key[Array, '']) -> bool:


### PR DESCRIPTION
\`Forest.leaf_indices\` is by far the largest array in the MCMC state, and \`step\` was making XLA materialize up to several extra full copies of it, dominating peak memory at scale (e.g. 32 GiB per copy at n=16Mi, 1024 trees, 2 chains). The last straw was openxla/xla#45912, a jaxlib 0.7.2 buffer-assignment regression that adds yet another copy even in the previously-clean no-chains case; rather than waiting for a fix upstream, this PR restructures \`step\` so the copies (including that one) don't arise in the first place. Measured extra peak memory on cpu drops from ~2–4 copies of \`leaf_indices\` to ~0.03–2 depending on chain setup, gpu to ~0.01–0.02, and the step gets faster on both platforms (cpu 2 chains: 2.2x).

The copies came from layout mismatches and from an update pattern XLA can't do in place. The changes, in order:

- **Defer the prune update**: the prune from a step's moves is now applied to \`leaf_indices\` at the beginning of the *next* step (recorded in new \`Forest.to_prune\`/\`move_node\` fields), so every update within a step is elementwise and sits before the sequential tree loop, letting XLA reuse the donated buffer instead of copying. The leaf-mirroring trick in the sequential stage keeps the not-yet-pruned indices valid for evaluating the trees.
- **Skip tree batching on gpu**: the \`lax.map\` over tree batches in the count/precision-tree computation only exists to bound reduction temporaries on cpu; on gpu they fuse anyway, and under the chain vmap the map's reshape became a full transposed copy of \`leaf_indices\`. Now split with \`lax.platform_dependent\`.
- **Lead chain axis**: \`Forest.leaf_indices\` goes back to a leading chain axis (reverting e27dc23c); the sequential scan closes over the whole array and slices it by a \`tree_index\` xs, so the scan batching rules keep the chain axis where storage has it and no consumer triggers a transpose.
- **\`sliced_map\`**: new \`_jaxext\` utility with \`lax.map(..., batch_size=...)\` semantics that reads xs by slicing a closed-over value in the scan body, used for the cpu count-tree batching for the same layout reason.
- **\`StepMemorySharded\` benchmark**: measures the per-device memory footprint of \`step\` on a state sharded over data/chains mesh axes, rescaled to the all-devices total so replicated buffers show up as excess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)