### PR TITLE
docs(make): check colab notebook before release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,12 @@ help:
 	@echo "Release workflow:"
 	@echo "- describe release in docs/changelog.md (its topmost header sets the version, follow effver https://jacobtomlinson.dev/effver)"
 	@echo "- $$ make release, will not release but runs all tests, iterate and debug"
-	@echo "- merge a PR with the changes"
 	@echo '- run `make tests-gpu` on a gpu'
-	@echo "- do a PR that re-runs benchmarks"
+	@echo "- merge a PR with the changes and fixes"
+	@echo "- do a PR that re-runs benchmarks on cpu & gpu, fix performance regressions"
+	@echo '- open the README colab link, run `%pip install git+https://github.com/bartz-org/bartz@main` in a scratch cell, then run all'
+	@echo '- iterate until example notebook works on colab with main'
+	@echo '- save notebook locally and commit it'
 	@echo "- on main: $$ make release"
 	@echo "- merge fix PR and try again until make release passes"
 	@echo "- publish the draft github release created by make release (updates zenodo automatically)"


### PR DESCRIPTION
Adds a step to the `make help` release checklist to verify the README example notebook runs on Colab against main before releasing, and clarifies the ordering of the benchmark and fix-merging steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)